### PR TITLE
Some minor fixes.

### DIFF
--- a/minecode/src/discovery/debutils.py
+++ b/minecode/src/discovery/debutils.py
@@ -21,7 +21,7 @@ def parse_email(text):
     email = email.strip()
     if not email:
         return name, email
-    email.strip('>')
+    email = email.strip('>')
     return name, email
 
 


### PR DESCRIPTION
Some minor fixes in:

1. debutils.py: Now email can be correctly extracted.
2. mappers/debian.py: Now we can correctly seperate dependacy name and constraint versions.

Signed-off-by: Jay <jaykumar20march@gmail.com>