### PR TITLE
Some minor fixes in minecode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ tcl
 
 # Ignore Jupyter Notebook related temp files
 .ipynb_checkpoints/
+
+# Env Files
+.env

--- a/minecode/debutils.py
+++ b/minecode/debutils.py
@@ -8,7 +8,6 @@
 #
 
 
-
 def parse_email(text):
     """
     Return a tuple of (name, email) extracted from a `text` string.
@@ -17,12 +16,10 @@ def parse_email(text):
     if not text:
         return None, None
     name, _, email = text.partition('<')
+    email = email.strip('>')
     name = name.strip()
     email = email.strip()
-    if not email:
-        return name, email
-    email = email.strip('>')
-    return name, email
+    return name or None, email or None
 
 
 def comma_separated(text):

--- a/minecode/debutils.py
+++ b/minecode/debutils.py
@@ -21,7 +21,7 @@ def parse_email(text):
     email = email.strip()
     if not email:
         return name, email
-    email.strip('>')
+    email = email.strip('>')
     return name, email
 
 

--- a/minecode/mappers/debian.py
+++ b/minecode/mappers/debian.py
@@ -50,31 +50,17 @@ def get_dependencies(data):
         if not depends:
             continue
 
-        dependencies = debutils.comma_separated(depends)
-        name_version = []
-        for dependency in dependencies:
-            version_constraint = None
-            if "(" in dependency and ")" in dependency:
-                start = dependency.index("(")
-                end = dependency.index(")")
-                version_constraint = dependency[start + 1:end]
-            name = dependency.split(" ")[0]
-            name_version.append([name, version_constraint])
-
+        dependencies = None  # debutils.comma_separated(depends)
+        if not dependencies:
+            continue
         # break each dep in package names and version constraints
         # FIXME:!!!
-        # FIXED !!!
-        for name, version_constraint in name_version:
-            purl = PackageURL(type="deb", namespace="debian", name=name)
-            dep = DependentPackage(
-                purl=purl.to_string(),
-                scope=scope,
-                requirement=version_constraint,
-                **flags,
-            )
+        for name in dependencies:
+            purl = PackageURL(type='deb', namespace='debian', name=name)
+            dep = scan_models.DependentPackage(purl=purl.to_string(), score=scope, **flags)
             dep_pkgs.append(dep)
 
-        return dep_pkgs
+    return dep_pkgs
 
 
 def get_vcs_repo(description):

--- a/minecode/mappers/debian.py
+++ b/minecode/mappers/debian.py
@@ -22,12 +22,12 @@ from minecode import map_router
 from minecode.mappers import Mapper
 from minecode.utils import form_vcs_url
 from minecode import debutils
-from packagedb.models import DependentPackage
 
 logger = logging.getLogger(__name__)
 handler = logging.StreamHandler()
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
+
 
 # FIXME: We are not returning download URLs. Returned information is incorrect
 
@@ -345,6 +345,7 @@ def parse_packages(metadata, purl=None):
         if purl:
             package.set_purl(purl)
         yield package
+
 
 #################################################################################
 # FIXME: this cannot work since we do not fetch these yet AND what are the zip jar and gz in this???

--- a/minecode/tests/test_debian.py
+++ b/minecode/tests/test_debian.py
@@ -102,21 +102,28 @@ class DebutilsTest(BaseDebianTest):
         result = debcon.get_paragraph_data_from_file(dsc_file)
         expected_loc = self.get_test_loc('debian/debutils/3dldf_2.0.3+dfsg-2.dsc-expected')
         self.check_expected_deb822(result, expected_loc, regen=False)
+
     #################################################################
 
-    @expectedFailure
     def test_parse_email(self):
         content = 'Debian TeX Maintainers <debian-tex-maint@lists.debian.org>'
         name, email = debutils.parse_email(content)
         self.assertEquals('Debian TeX Maintainers', name)
-        self.assertEquals('debian-tex-maint@lists.debian.org', email)
+        self.assertEquals('debian-tex-main.debian.org', email)
 
-    @expectedFailure
     def test_parse_email_2(self):
-        content = 'Debian TeX Maintainers '
+        # Space left Purposefully
+        content = '        Debian TeX Maintainers '
         name, email = debutils.parse_email(content)
         self.assertEquals('Debian TeX Maintainers', name)
         self.assertEquals(None, email)
+
+    def test_parse_email_3(self):
+        # Space left Purposefully
+        content = '<       debian-tex-maint@lists.debian.org   >'
+        name, email = debutils.parse_email(content)
+        self.assertEquals(None, name)
+        self.assertEquals("debian-tex-maint@lists.debian.org", email)
 
     def test_comma_separated(self):
         tags = 'implemented-in::perl, role::program, use::converting, works-with::pim'

--- a/minecode/tests/test_debian.py
+++ b/minecode/tests/test_debian.py
@@ -109,7 +109,7 @@ class DebutilsTest(BaseDebianTest):
         content = 'Debian TeX Maintainers <debian-tex-maint@lists.debian.org>'
         name, email = debutils.parse_email(content)
         self.assertEquals('Debian TeX Maintainers', name)
-        self.assertEquals('debian-tex-main.debian.org', email)
+        self.assertEquals('debian-tex-maint@lists.debian.org', email)
 
     def test_parse_email_2(self):
         # Space left Purposefully


### PR DESCRIPTION
Some minor fixes in:

1. debutils.py: Now email can be correctly extracted.
2. mappers/debian.py: Now we can correctly seperate dependacy name and constraint versions.

Signed-off-by: Jay <jaykumar20march@gmail.com>