### PR TITLE
Fixes in Debian Index Visitor function.

### DIFF
--- a/minecode/mappers/debian.py
+++ b/minecode/mappers/debian.py
@@ -17,6 +17,7 @@ from debian_inspector import debcon
 from packagedcode import models as scan_models
 from packageurl import PackageURL
 
+import debutils
 from minecode import ls
 from minecode import map_router
 from minecode.mappers import Mapper

--- a/minecode/visitors/debian.py
+++ b/minecode/visitors/debian.py
@@ -86,7 +86,7 @@ class DebianDirectoryIndexVisitor(NonPersistentHttpVisitor):
     Collect package URIs from Debian-like repos with an ls-LR directory listing.
     """
     def get_uris(self, content):
-        with gzip.open(content, 'rb') as f:
+        with gzip.open(content, 'rt') as f:
             content = f.read()
 
         url_template = self.uri.replace('ls-lR.gz', '{path}')
@@ -114,7 +114,7 @@ class DebianDirectoryIndexVisitor(NonPersistentHttpVisitor):
                 type='deb',
                 namespace=namespace,
                 name=name,
-                version=version,
+                version=str(version),
                 qualifiers=dict(arch=arch) if arch else None)
 
             yield URI(


### PR DESCRIPTION
Closes #23
Gzip file content will read as text instead of bytes. String version Will be passed instead of Version Object.
Signed-off-by: Jay <jaykumar20march@gmail.com>