### PR TITLE
Raise caught exception in _call_scan_get_api #167

### DIFF
--- a/minecode/management/commands/process_scans.py
+++ b/minecode/management/commands/process_scans.py
@@ -5,6 +5,7 @@
 import logging
 import signal
 import sys
+import traceback
 
 from django.db import transaction
 
@@ -148,7 +149,8 @@ class Command(scanning.ScanningCommand):
                     scannable_uri.priority = 0
 
             except Exception as e:
-                error_message = str(e) + '\n'
+                traceback_message = traceback.format_exc()
+                error_message = traceback_message + '\n'
                 # TODO: We should rerun the specific indexers that have failed
                 if scan_index_errors:
                     error_message += '\n'.join(scan_index_errors)

--- a/minecode/management/scanning.py
+++ b/minecode/management/scanning.py
@@ -269,9 +269,14 @@ def _call_scan_get_api(
     exception on error.
     """
     scan_url = get_scan_url(scan_uuid, api_url=api_url, suffix=endpoint)
-    response = requests.get(url=scan_url, timeout=timeout, headers=api_auth_headers)
-    if not response.ok:
-        response.raise_for_status()
+    try:
+        response = requests.get(url=scan_url, timeout=timeout, headers=api_auth_headers)
+        if not response.ok:
+            response.raise_for_status()
+    except Exception:
+        # Ensure that exceptions are passed up the call stack, so they can be
+        # caught when _call_scan_get_api is called by another function.
+        raise
     return response.json()
 
 


### PR DESCRIPTION
    * This allows us to capture this exception when we call _call_scan_get_api from another function
    * Save entire traceback message in index_error