### PR TITLE
Improve version range resolution

### DIFF
--- a/minecode/tests/testfiles/directories/ls-lr-expected.json
+++ b/minecode/tests/testfiles/directories/ls-lr-expected.json
@@ -3,7 +3,7 @@
     "path":"README",
     "type":"f",
     "size":1499,
-    "date":"2022-09",
+    "date":"2023-09",
     "target":null
   },
   {
@@ -17,7 +17,7 @@
     "path":"README.html",
     "type":"f",
     "size":3185,
-    "date":"2022-09",
+    "date":"2023-09",
     "target":null
   },
   {
@@ -45,7 +45,7 @@
     "path":"dists/README",
     "type":"f",
     "size":932,
-    "date":"2022-09",
+    "date":"2023-09",
     "target":null
   },
   {

--- a/packagedb/api.py
+++ b/packagedb/api.py
@@ -45,7 +45,7 @@ from packagedb.package_managers import VERSION_API_CLASSES_BY_PACKAGE_TYPE
 
 from univers import versions
 from univers.version_range import RANGE_CLASS_BY_SCHEMES
-from univers.version_range import InvalidVersionRange
+from univers.versions import InvalidVersion
 from univers.version_range import VersionRange
 
 
@@ -750,7 +750,6 @@ def resolve_versions(parsed_purl, vers):
     all_versions = get_all_versions(parsed_purl) or []
 
     result = []
-
     for version in all_versions:
         try:
             if version in version_range:
@@ -783,10 +782,17 @@ def get_all_versions(purl: PackageURL):
     if not package_name or not versionAPI:
         return
 
-    all_versions = versionAPI().fetch(package_name)
+    all_versions = versionAPI().fetch(package_name) or []
     versionClass = VERSION_CLASS_BY_PACKAGE_TYPE.get(purl.type)
 
-    return [versionClass(package_version.value) for package_version in all_versions]
+    result = []
+    for package_version in all_versions:
+        try:
+            result.append(versionClass(package_version.value))
+        except InvalidVersion:
+            pass
+    
+    return result
 
 
 VERSION_CLASS_BY_PACKAGE_TYPE = {pkg_type: range_class.version_class for pkg_type, range_class in RANGE_CLASS_BY_SCHEMES.items()}

--- a/packagedb/api.py
+++ b/packagedb/api.py
@@ -405,8 +405,9 @@ class PackageViewSet(viewsets.ReadOnlyModelViewSet):
         packages = request.data.get('packages') or []
         queued_packages = []
         unqueued_packages = []
+        supported_ecosystem = ["maven","npm"]
 
-        unique_purls, unsupported_packages, unsupported_vers = get_resolved_purls(packages)
+        unique_purls, unsupported_packages, unsupported_vers = get_resolved_purls(packages, supported_ecosystem)
 
         for purl in unique_purls:
             is_routable_purl = priority_router.is_routable(purl)
@@ -691,7 +692,7 @@ class PackageSetViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = PackageSetAPISerializer
 
 
-def get_resolved_purls(packages):
+def get_resolved_purls(packages, supported_ecosystem):
     """
     Take a list of dict containing purl or version-less purl along with vers
     and return a list of resolved purls, a list of unsupported purls, and a
@@ -718,7 +719,7 @@ def get_resolved_purls(packages):
             unique_resolved_purls.add(purl)
             continue
 
-        if not vers:
+        if not vers or parsed_purl.type not in supported_ecosystem:
             unsupported_purls.add(purl)
             continue
 

--- a/packagedb/api.py
+++ b/packagedb/api.py
@@ -749,18 +749,23 @@ def resolve_versions(parsed_purl, vers):
 
     all_versions = get_all_versions(parsed_purl) or []
 
-    return [
-        str(
-            PackageURL(
-                type=parsed_purl.type,
-                namespace=parsed_purl.namespace,
-                name=parsed_purl.name,
-                version=version.string,
-            )
-        )
-        for version in all_versions
-        if version in version_range
-    ]
+    result = []
+
+    for version in all_versions:
+        try:
+            if version in version_range:
+                package_url = PackageURL(
+                    type=parsed_purl.type,
+                    namespace=parsed_purl.namespace,
+                    name=parsed_purl.name,
+                    version=version.string,
+                )
+                result.append(str(package_url))
+        except Exception:
+            # Skip the ``Invalid constraints sequence`` Exception
+            pass
+
+    return result
 
 def get_all_versions(purl: PackageURL):
     """

--- a/packagedb/api.py
+++ b/packagedb/api.py
@@ -48,6 +48,7 @@ from univers import versions
 from univers.version_range import RANGE_CLASS_BY_SCHEMES
 from univers.versions import InvalidVersion
 from univers.version_range import VersionRange
+from univers.version_constraint import InvalidConstraintsError
 
 logger = logging.getLogger(__name__)
 
@@ -763,8 +764,7 @@ def resolve_versions(parsed_purl, vers):
                     version=version.string,
                 )
                 result.append(str(package_url))
-        except Exception:
-            # Skip the ``Invalid constraints sequence`` Exception
+        except InvalidConstraintsError:
             logger.warning(f"Invalid constraints sequence in '{vers}' for '{parsed_purl}'")
             return
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ install_requires =
     scancode-toolkit[full] == 32.0.6
     urlpy == 0.5
     matchcode-toolkit >= 1.1.1
-    univers == 30.10.1
+    univers == 30.11.0
 setup_requires = setuptools_scm[toml] >= 4
 
 python_requires = >=3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ install_requires =
     scancode-toolkit[full] == 32.0.6
     urlpy == 0.5
     matchcode-toolkit >= 1.1.1
-    univers == 30.10.0
+    univers == 30.10.1
 setup_requires = setuptools_scm[toml] >= 4
 
 python_requires = >=3.8


### PR DESCRIPTION
- [x] Handle `invalid constraints sequence` exception while testing whether a given version is present in given `vers` expression 
- [x] Handle potential invalid version string
- [x] Skip vers resolution for unsupported ecosystems, currently `on_demand_queue` only supports `maven` and `npm`
- [x] Bump univers to v30.10.1