### PR TITLE
Package field update method

### DIFF
--- a/packagedb/models.py
+++ b/packagedb/models.py
@@ -755,7 +755,7 @@ class Package(
 
                     msg = f"Replaced {model_count} existing entries of field '{field}' with {created_models_count} new entries."
                     self.append_to_history(msg)
-                    replaced_fields.append(field)
+                    replaced_fields.extend([field, 'history'])
             else:
                 # Ensure the incoming value is of the correct type
                 if field == 'qualifiers' and isinstance(value, dict):
@@ -788,10 +788,7 @@ class Package(
                 history_entries.append(entry)
                 updated_fields.append(field)
 
-        if updated_fields:
-            updated_fields.append('history')
-            # Deduplicate field names
-            updated_fields = list(set(updated_fields))
+        if updated_fields and history_entries:
             data = {
                 'updated_fields': history_entries,
             }
@@ -799,9 +796,14 @@ class Package(
                 'Package field values have been updated.',
                 data=data,
             )
+            updated_fields.append('history')
 
         if replaced_fields:
             updated_fields.extend(replaced_fields)
+
+        if updated_fields:
+            # Deduplicate field names
+            updated_fields = list(set(updated_fields))
 
         if save:
             self.save()

--- a/packagedb/models.py
+++ b/packagedb/models.py
@@ -7,6 +7,7 @@
 # See https://aboutcode.org for more information about nexB OSS projects.
 #
 
+from collections import OrderedDict
 import copy
 import logging
 import natsort
@@ -14,20 +15,19 @@ import sys
 import uuid
 
 from django.contrib.postgres.fields import ArrayField
-from django.contrib.postgres.indexes import GinIndex
-from django.contrib.postgres.search import SearchVectorField
 from django.core.paginator import Paginator
 from django.db import models
+from django.db import transaction
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from dateutil.parser import parse as dateutil_parse
 from licensedcode.cache import build_spdx_license_expression
+from packagedcode.models import normalize_qualifiers
 from packageurl import PackageURL
 from packageurl.contrib.django.models import PackageURLMixin
 from packageurl.contrib.django.models import PackageURLQuerySetMixin
 
-from packagedcode.models import normalize_qualifiers
-from dateutil.parser import parse as dateutil_parse
 TRACE = False
 
 logger = logging.getLogger(__name__)
@@ -455,6 +455,11 @@ class PackageContentType(models.IntegerChoices):
     DOC = 7, 'doc'
 
 
+def get_class_name(obj):
+    """Return a string containing the class name of `obj`"""
+    return type(obj).__name__
+
+
 # TODO: Figure out what ordering we want for the fields
 class Package(
     HistoryMixin,
@@ -626,64 +631,6 @@ class Package(
         if scannable_uri:
             scannable_uri.rescan()
 
-    def _update_field(self, field, value):
-        """
-        Update `field` of this Package with a value of `value` and return a
-        3-tuple containing this Package, a list of fields that were updated, and
-        a list of history entries.
-        """
-        # Ensure the incoming value is of the correct type
-        if field == 'qualifiers' and isinstance(value, dict):
-            value = normalize_qualifiers(value, encode=True)
-
-        date_fields = [
-            'created_date',
-            'last_indexed_date',
-            'last_modified_date',
-            'release_date',
-        ]
-        if field in date_fields and isinstance(value, str):
-            value = dateutil_parse(value)
-
-        history_entries = []
-        # Update Package value
-        package_value = getattr(self, field)
-        setattr(self, field, value)
-
-        # Update history
-        if field in date_fields:
-            package_value = str(package_value)
-            value = str(value)
-        entry = dict(
-            field=field,
-            old_value=package_value,
-            new_value=value,
-        )
-        updated_fields = [field, 'history']
-        history_entries.append(entry)
-        return self, updated_fields, history_entries
-
-    def update_field(self, field, value, save=False):
-        """
-        Update `field` of this Package with a value of `value` and return a
-        2-tuple containing this Package and a list of fields that were updated.
-        """
-        package, updated_fields, history_entries = self._update_field(field=field, value=value)
-
-        if updated_fields:
-            data = {
-                'updated_fields': history_entries,
-            }
-            self.append_to_history(
-                'Package field values have been updated.',
-                data=data,
-            )
-
-        if save:
-            package.save()
-
-        return package, updated_fields
-
     def update_fields(self, save=False, **values_by_fields):
         """
         Given keyword arguments from `values_by_fields`, where the argument
@@ -692,22 +639,159 @@ class Package(
         path="/new/path", sha1="newsha1"), update all the fields and return a
         2-tuple containing this Package and a list containing the fields that
         were updated.
+
+        In the instance where the field to be updated is `dependencies`,
+        `parties`, or `resources`, then we will delete all existing related
+        models for that field and then create the new models from the argument
+        values.
         """
+        class_name = get_class_name(self)
+        replaced_fields = []
         updated_fields = []
         history_entries = []
         for field, value in values_by_fields.items():
-            (
-                package,
-                uf,
-                he
-            ) = self._update_field(field=field, value=value)
-            updated_fields.extend(uf)
-            history_entries.extend(he)
+            if not hasattr(self, field):
+                # Raise exception when we we are given a keyword argument that
+                # doesn't correspond to a Package field
+                raise AttributeError(f"'{class_name}' has no attribute '{field}'")
 
-        # Deduplicate field names
-        updated_fields = list(set(updated_fields))
+            related_model_fields = [
+                'dependencies',
+                'parties',
+                'resources',
+            ]
+            if field in related_model_fields:
+                unsaved_models = []
+                if field == 'dependencies':
+                    for dep_data in value:
+                        if isinstance(dep_data, (dict, OrderedDict)):
+                            dep = DependentPackage(
+                                package=self,
+                                purl=dep_data.get('purl'),
+                                extracted_requirement=dep_data.get('extracted_requirement'),
+                                scope=dep_data.get('scope'),
+                                is_runtime=dep_data.get('is_runtime'),
+                                is_optional=dep_data.get('is_optional'),
+                                is_resolved=dep_data.get('is_resolved'),
+                            )
+                        elif isinstance(dep_data, DependentPackage):
+                            dep = dep_data
+                        else:
+                            raise ValueError(
+                                f"Cannot save object of type '{get_class_name(dep_data)}' to field '{field}' of type 'DependentPackage'"
+                            )
+                        unsaved_models.append(dep)
+
+                if field == 'parties':
+                    for party_data in value:
+                        if isinstance(party_data, (dict, OrderedDict)):
+                            party = Party(
+                                package=self,
+                                type=party_data.get('type'),
+                                role=party_data.get('role'),
+                                name=party_data.get('name'),
+                                email=party_data.get('email'),
+                                url=party_data.get('url'),
+                            )
+                        elif isinstance(party_data, Party):
+                            party = party_data
+                        else:
+                            raise ValueError(
+                                f"Cannot save object of type '{get_class_name(party_data)}' to field '{field}' of type 'Party'"
+                            )
+                        unsaved_models.append(party)
+
+                if field == 'resources':
+                    for resource_data in value:
+                        if isinstance(resource_data, (dict, OrderedDict)):
+                            resource = Resource(
+                                package=self,
+                                path=resource_data.get('path'),
+                                is_file=resource_data.get('type') == 'file',
+                                name=resource_data.get('name'),
+                                extension=resource_data.get('extension'),
+                                size=resource_data.get('size'),
+                                md5=resource_data.get('md5'),
+                                sha1=resource_data.get('sha1'),
+                                sha256=resource_data.get('sha256'),
+                                mime_type=resource_data.get('mime_type'),
+                                file_type=resource_data.get('file_type'),
+                                programming_language=resource_data.get('programming_language'),
+                                is_binary=resource_data.get('is_binary'),
+                                is_text=resource_data.get('is_text'),
+                                is_archive=resource_data.get('is_archive'),
+                                is_media=resource_data.get('is_media'),
+                                is_key_file=resource_data.get('is_key_file'),
+                            )
+                            resource.set_scan_results(resource_data)
+                        elif isinstance(resource_data, Resource):
+                            resource = resource_data
+                        else:
+                            raise ValueError(
+                                f"Cannot save object of type '{get_class_name(resource_data)}' to field '{field}' of type 'Resource'"
+                            )
+                        unsaved_models.append(resource)
+
+                if unsaved_models:
+                    created_models_count = len(unsaved_models)
+                    model_count = 0
+                    if field == 'dependencies':
+                        model_count = self.dependencies.all().count()
+                        with transaction.atomic():
+                            self.dependencies.all().delete()
+                            DependentPackage.objects.bulk_create(unsaved_models)
+
+                    if field == 'parties':
+                        model_count = self.parties.all().count()
+                        with transaction.atomic():
+                            self.parties.all().delete()
+                            Party.objects.bulk_create(unsaved_models)
+
+                    if field == 'resources':
+                        model_count = self.resources.all().count()
+                        with transaction.atomic():
+                            self.resources.all().delete()
+                            Resource.objects.bulk_create(unsaved_models)
+
+                    msg = f"Replaced {model_count} existing entries of field '{field}' with {created_models_count} new entries."
+                    self.append_to_history(msg)
+                    replaced_fields.append(field)
+            else:
+                # Ensure the incoming value is of the correct type
+                if field == 'qualifiers' and isinstance(value, dict):
+                    value = normalize_qualifiers(value, encode=True)
+
+                date_fields = [
+                    'created_date',
+                    'last_indexed_date',
+                    'last_modified_date',
+                    'release_date',
+                ]
+                if field in date_fields and isinstance(value, str):
+                    value = dateutil_parse(value)
+
+                # Update field value
+                package_value = getattr(self, field)
+                setattr(self, field, value)
+
+                # Cast datetime value to a string for history
+                if field in date_fields:
+                    package_value = str(package_value)
+                    value = str(value)
+
+                # Create entry for history
+                entry = dict(
+                    field=field,
+                    old_value=package_value,
+                    new_value=value,
+                )
+                history_entries.append(entry)
+                updated_fields.append(field)
 
         if updated_fields:
+            updated_fields.append('history')
+            # Deduplicate field names
+            updated_fields = list(set(updated_fields))
             data = {
                 'updated_fields': history_entries,
             }
@@ -716,10 +800,13 @@ class Package(
                 data=data,
             )
 
-        if save:
-            package.save()
+        if replaced_fields:
+            updated_fields.extend(replaced_fields)
 
-        return package, updated_fields
+        if save:
+            self.save()
+
+        return self, updated_fields
 
 
 party_person = 'person'
@@ -783,6 +870,11 @@ class Party(models.Model):
         help_text=_('URL to a primary web page for this party.')
     )
 
+    def to_dict(self):
+        from packagedb.serializers import PartySerializer
+        party_data = PartySerializer(self).data
+        return party_data
+
 
 class DependentPackage(models.Model):
     """
@@ -833,6 +925,11 @@ class DependentPackage(models.Model):
                     'been resolved and this dependency url points to an '
                     'exact version.')
     )
+
+    def to_dict(self):
+        from packagedb.serializers import DependentPackageSerializer
+        depedent_package_data = DependentPackageSerializer(self).data
+        return depedent_package_data
 
 
 class AbstractResource(models.Model):

--- a/packagedb/models.py
+++ b/packagedb/models.py
@@ -76,7 +76,6 @@ class PackageQuerySet(PackageURLQuerySetMixin, models.QuerySet):
                 yield object
 
 
-
 VCS_CHOICES = [
     ('git', 'git'),
     ('svn', 'subversion'),
@@ -649,11 +648,11 @@ class Package(
             setattr(self, field, value)
             # Update history
             if field in date_fields:
-                p_val = str(p_val)
+                package_value = str(package_value)
                 value = str(value)
             entry = dict(
                 field=field,
-                old_value=p_val,
+                old_value=package_value,
                 new_value=value,
             )
             updated_field = field
@@ -695,11 +694,11 @@ class Package(
                 setattr(self, field, value)
                 # Update history
                 if field in date_fields:
-                    p_val = str(p_val)
+                    package_value = str(package_value)
                     value = str(value)
                 entry = dict(
                     field=field,
-                    old_value=p_val,
+                    old_value=package_value,
                     new_value=value,
                 )
                 updated_fields.append(field)

--- a/packagedb/tests/test_models.py
+++ b/packagedb/tests/test_models.py
@@ -141,3 +141,85 @@ class PackageModelTestCase(TransactionTestCase):
         self.assertEqual(p3, p2.get_latest_version())
         self.assertEqual(p3, p3.get_latest_version())
         self.assertEqual(p4, p4.get_latest_version())
+
+    def test_packagedb_package_model_update_field(self):
+        p1 = Package.objects.create(download_url='http://a.a', name='name', version='1.0')
+        self.assertFalse(p1.history)
+        self.assertEquals('', p1.namespace)
+        package, updated_field = p1.update_field(field='namespace', value='test')
+        self.assertEqual(updated_field, 'namespace')
+        self.assertEqual('test', p1.namespace)
+        self.assertEqual(1, len(p1.history))
+        expected_history_entry = {
+            'message': 'Package field values have been updated.',
+            'data': {
+                'updated_fields':
+                [
+                    {
+                        'field': 'namespace',
+                        'old_value': '',
+                        'new_value': 'test'
+                    }
+                ]
+            }
+        }
+        history_entry = p1.history[0]
+        history_entry.pop('timestamp')
+        self.assertEqual(expected_history_entry, history_entry)
+
+    def test_packagedb_package_model_update_field(self):
+        p1 = Package.objects.create(download_url='http://a.a', name='name', version='1.0')
+        self.assertFalse(p1.history)
+        self.assertEquals('', p1.namespace)
+        package, updated_field = p1.update_field(field='namespace', value='test')
+        self.assertEqual(updated_field, 'namespace')
+        self.assertEqual('test', p1.namespace)
+        self.assertEqual(1, len(p1.history))
+        expected_history_entry = {
+            'message': 'Package field values have been updated.',
+            'data': {
+                'updated_fields':
+                [
+                    {
+                        'field': 'namespace',
+                        'old_value': '',
+                        'new_value': 'test'
+                    }
+                ]
+            }
+        }
+        history_entry = p1.history[0]
+        history_entry.pop('timestamp')
+        self.assertEqual(expected_history_entry, history_entry)
+
+    def test_packagedb_package_model_update_fields(self):
+        p1 = Package.objects.create(download_url='http://a.a', name='name', version='1.0')
+        self.assertFalse(p1.history)
+        self.assertEquals('', p1.namespace)
+        self.assertEquals(None, p1.homepage_url)
+        package, updated_fields = p1.update_fields(namespace='test', homepage_url='https://example.com')
+        self.assertEqual(updated_fields, ['namespace', 'homepage_url'])
+        self.assertEqual('test', p1.namespace)
+        self.assertEqual('https://example.com', p1.homepage_url)
+        self.assertEqual(1, len(p1.history))
+        expected_history_entry = {
+            'message': 'Package field values have been updated.',
+            'data': {
+                'updated_fields':
+                [
+                    {
+                        'field': 'namespace',
+                        'old_value': '',
+                        'new_value': 'test'
+                    },
+                    {
+                        'field': 'homepage_url',
+                        'old_value': None,
+                        'new_value': 'https://example.com'
+                    }
+                ]
+            }
+        }
+        history_entry = p1.history[0]
+        history_entry.pop('timestamp')
+        self.assertEqual(expected_history_entry, history_entry)

--- a/packagedb/tests/test_models.py
+++ b/packagedb/tests/test_models.py
@@ -172,7 +172,7 @@ class PackageModelTestCase(TransactionTestCase):
         self.assertFalse(p1.history)
         self.assertEquals('', p1.namespace)
         package, updated_field = p1.update_field(field='namespace', value='test')
-        self.assertEqual(updated_field, 'namespace')
+        self.assertEqual(updated_field, ['namespace', 'history'])
         self.assertEqual('test', p1.namespace)
         self.assertEqual(1, len(p1.history))
         expected_history_entry = {
@@ -198,7 +198,10 @@ class PackageModelTestCase(TransactionTestCase):
         self.assertEquals('', p1.namespace)
         self.assertEquals(None, p1.homepage_url)
         package, updated_fields = p1.update_fields(namespace='test', homepage_url='https://example.com')
-        self.assertEqual(updated_fields, ['namespace', 'homepage_url'])
+        self.assertEqual(
+            sorted(updated_fields),
+            sorted(['homepage_url', 'history', 'namespace'])
+        )
         self.assertEqual('test', p1.namespace)
         self.assertEqual('https://example.com', p1.homepage_url)
         self.assertEqual(1, len(p1.history))

--- a/packagedb/tests/test_models.py
+++ b/packagedb/tests/test_models.py
@@ -431,3 +431,17 @@ class PackageModelTestCase(TransactionTestCase):
         self.assertEqual(1, len(p6.history))
         history_message = p6.history[0]['message']
         self.assertEqual(expected_message, history_message)
+
+    def test_packagedb_package_model_update_fields_exceptions(self):
+        p1 = Package.objects.create(download_url='http://a.a', name='name', version='1.0')
+        with self.assertRaises(AttributeError):
+            p1.update_fields(asdf=123)
+
+        with self.assertRaises(ValueError):
+            p1.update_fields(resources=[1])
+
+        with self.assertRaises(ValueError):
+            p1.update_fields(dependencies=[1])
+
+        with self.assertRaises(ValueError):
+            p1.update_fields(parties=[1])

--- a/packagedb/tests/test_models.py
+++ b/packagedb/tests/test_models.py
@@ -288,7 +288,11 @@ class PackageModelTestCase(TransactionTestCase):
         p1 = Package.objects.create(download_url='http://a.a', name='name', version='1.0')
         path = 'asdf'
         resources = [Resource(package=p1, path=path)]
-        p1.update_fields(resources=resources)
+        _, updated_fields = p1.update_fields(resources=resources)
+        self.assertEquals(
+            sorted(['resources', 'history']),
+            sorted(updated_fields)
+        )
         expected_message = "Replaced 0 existing entries of field 'resources' with 1 new entries."
         self.assertEqual(1, len(p1.history))
         history_message = p1.history[0]['message']
@@ -334,7 +338,11 @@ class PackageModelTestCase(TransactionTestCase):
                 "extra_data": {}
             }
         ]
-        p2.update_fields(resources=resources)
+        _, updated_fields = p2.update_fields(resources=resources)
+        self.assertEquals(
+            sorted(['resources', 'history']),
+            sorted(updated_fields)
+        )
         expected_message = "Replaced 0 existing entries of field 'resources' with 1 new entries."
         self.assertEqual(1, len(p2.history))
         history_message = p2.history[0]['message']
@@ -350,7 +358,11 @@ class PackageModelTestCase(TransactionTestCase):
                 url='foo.com',
              )
         ]
-        p3.update_fields(parties=parties)
+        _, updated_fields = p3.update_fields(parties=parties)
+        self.assertEquals(
+            sorted(['parties', 'history']),
+            sorted(updated_fields)
+        )
         expected_message = "Replaced 0 existing entries of field 'parties' with 1 new entries."
         self.assertEqual(1, len(p3.history))
         history_message = p3.history[0]['message']
@@ -367,7 +379,11 @@ class PackageModelTestCase(TransactionTestCase):
                 url='foo.com',
              )
         ]
-        p4.update_fields(parties=parties)
+        _, updated_fields = p4.update_fields(parties=parties)
+        self.assertEquals(
+            sorted(['parties', 'history']),
+            sorted(updated_fields)
+        )
         expected_message = "Replaced 0 existing entries of field 'parties' with 1 new entries."
         self.assertEqual(1, len(p4.history))
         history_message = p4.history[0]['message']
@@ -384,7 +400,11 @@ class PackageModelTestCase(TransactionTestCase):
                 is_resolved=True,
             )
         ]
-        p5.update_fields(dependencies=dependencies)
+        _, updated_fields = p5.update_fields(dependencies=dependencies)
+        self.assertEquals(
+            sorted(['dependencies', 'history']),
+            sorted(updated_fields)
+        )
         expected_message = "Replaced 0 existing entries of field 'dependencies' with 1 new entries."
         self.assertEqual(1, len(p5.history))
         history_message = p5.history[0]['message']
@@ -402,7 +422,11 @@ class PackageModelTestCase(TransactionTestCase):
                 is_resolved=True,
             )
         ]
-        p6.update_fields(dependencies=dependencies)
+        _, updated_fields = p6.update_fields(dependencies=dependencies)
+        self.assertEquals(
+            sorted(['dependencies', 'history']),
+            sorted(updated_fields)
+        )
         expected_message = "Replaced 0 existing entries of field 'dependencies' with 1 new entries."
         self.assertEqual(1, len(p6.history))
         history_message = p6.history[0]['message']


### PR DESCRIPTION
This PR adds a new method to the Package model to update fields. The idea is that we use these methods to update package fields, where it also updates the history as well.