### PR TITLE
Store scancode scans locally

### DIFF
--- a/clearcode/cdutils.py
+++ b/clearcode/cdutils.py
@@ -59,6 +59,8 @@ PACKAGE_TYPES_BY_CD_TYPE = {
     'nuget': 'nuget',
     'pypi': 'pypi',
     'gem': 'gem',
+    'npm': 'npm',
+    'go': 'golang',
 }
 
 
@@ -104,7 +106,7 @@ class Coordinate(object):
     ClearlyDefined coordinates are used to identify any tracked component.
     """
 
-    base_api_url = 'https://api.clearlydefined.io'
+    base_api_url = 'https://dev-api.clearlydefined.io'
 
     type = attr.ib()
     provider = attr.ib()
@@ -236,15 +238,15 @@ class Coordinate(object):
 
         >>> expected = 'pkg:maven/io.dropwizard/dropwizard@2.0.0-rc13'
         >>> test  = Coordinate('maven', 'mavencentral', 'io.dropwizard', 'dropwizard', '2.0.0-rc13').to_purl()
-        >>> assert expected == test
+        >>> assert expected == str(test)
 
         >>> expected = 'pkg:maven/io.dropwizard/dropwizard@2.0.0-rc13?classifier=sources'
         >>> test  = Coordinate('sourcearchive', 'mavencentral', 'io.dropwizard', 'dropwizard', '2.0.0-rc13').to_purl()
-        >>> assert expected == test
+        >>> assert expected == str(test)
 
         >>> expected = 'pkg:deb/debian/gedit-plugins@3.34.0-3?arch=source'
         >>> test  = Coordinate('debsrc', 'debian', '', 'gedit-plugins', '3.34.0-3').to_purl()
-        >>> assert expected == test
+        >>> assert expected == str(test)
         """
         converted_package_type = PACKAGE_TYPES_BY_CD_TYPE[self.type]
 
@@ -265,7 +267,7 @@ class Coordinate(object):
             name=self.name,
             version=self.revision,
             qualifiers=qualifiers,
-        ).to_string()
+        )
 
     @classmethod
     def from_purl(cls, purl):
@@ -519,6 +521,7 @@ def str2coord(s):
         URN: "urn:gem:rubygems:-:mocha:revision:1.7.0:tool:scancode:3.1.0"
         plain: /gem/rubygems/foo/mocha/1.7.0"
     """
+    #TODO: Add doctest
     is_urn = s.startswith('urn')
     is_url = s.startswith('cd:')
     splitter = ':' if is_urn else '/'

--- a/clearcode/management/commands/store_scans.py
+++ b/clearcode/management/commands/store_scans.py
@@ -1,7 +1,16 @@
+#
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# purldb is a trademark of nexB Inc.
+# SPDX-License-Identifier: Apache-2.0
+# See http://www.apache.org/licenses/LICENSE-2.0 for the license text.
+# See https://github.com/nexB/purldb for support or download.
+# See https://aboutcode.org for more information about nexB OSS projects.
+#
+
 from clearcode.store_scans import store_scancode_scans_from_cd_items
+from minecode.management.commands import VerboseCommand
 
-
-class Command(BaseCommand):
+class Command(VerboseCommand):
     help = 'Store scancode scans in git repositories'
 
     def add_arguments(self, parser):

--- a/clearcode/management/commands/store_scans.py
+++ b/clearcode/management/commands/store_scans.py
@@ -1,0 +1,13 @@
+from clearcode.store_scans import store_scancode_scans_from_cd_items
+
+
+class Command(BaseCommand):
+    help = 'Store scancode scans in git repositories'
+
+    def add_arguments(self, parser):
+        parser.add_argument('work_dir', type=str)
+        parser.add_argument('--github_org', type=str, default="")
+        parser.add_argument('--count', type=int, default=0)
+
+    def handle(self, *args, **options):
+        store_scancode_scans_from_cd_items(work_dir=options['work_dir'], github_org=options['github_org'], count=options['count'])

--- a/clearcode/store_scans.py
+++ b/clearcode/store_scans.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) nexB Inc. and others. All rights reserved.
+#
+# ClearCode is a free software tool from nexB Inc. and others.
+# Visit https://github.com/nexB/clearcode-toolkit/ for support and download.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from clearcode.models import CDitem
+from clearcode.cdutils import Coordinate
+from clearcode.cdutils import str2coord
+from django.db.models import Q
+from hashlib import sha512
+import json
+from packageurl import PackageURL
+from pathlib import Path
+from git import Repo
+
+"""
+The input is a bunch of scans from ClearlyDefined and 
+the output is a bunch of git repositories with commited and 
+pushed scans such that we balance the scans roughly evenly accross 
+different repositories.
+
+The primary reason for multiple repositories is size of a single 
+repo. There is a size limit of 5 GB at GitHub and it's difficult 
+to work with repositories with million files.
+
+Therefore the approach is to use hashing as a way to name git 
+repositories and directories. We compute hash on the purl of the scanned 
+package and use the first few layers of this hash for the repo and 
+directory names.
+
+Initial processing steps are:
+- We collect a list of scan and purl.
+- For each we compute a hash and determine the repo and directory.
+- If needed we create the repo or pull it.
+- Then we store the scan using the purl hash and purl as path.
+- Finally commit and push! : )
+
+Because it's not practical to process many repos at once, we organize the 
+processing one repo a time. For this, we iterate over a bunch of records get or compute 
+the purl hash and process the records that share the same hash.
+
+We are using a short hash that is three characters long using hexadecimal encoding. 
+Therefore we can have 16*16*16 = 4096 repositories where each repo would contain about 
+25k scan files, if we were to store 100 million scans (which is a high mark).
+For reference one scan should use less than a 100k on average when compressed 
+with gzip or git based on looking at 15 million scans. Each repo should be roughly 
+couple hundred mega bytes big, based on 15 million scans.
+"""
+
+repo_names = [hex(hash)[2:].zfill(3) for hash in range(4096)]
+
+def store_scancode_scans_from_cd_items(work_dir, github_org="", count=0):
+    """
+    Iterate over CDItem objects with scancode scans.  
+    Save and commit them in git repositories in work dir
+    """
+    cd_items = CDitem.objects.filter(~Q(content=b''), path__contains="tool/scancode")
+    x = get_cd_item_by_repo_name(cd_items=cd_items)
+    print(x)
+    for repo_name, cd_items in x.items():
+        for cd_item in cd_items:
+            data = cd_item.data
+            cd_url = data.get("_metadata", {}).get("url")
+            coordinate = Coordinate.from_dict(coords=str2coord(cd_url))
+            if not is_valid_coordinate(coordinate):
+                #TODO: this is a bug, we need to log it
+                continue
+            purl = coordinate.to_purl()
+            # temporary hack iterate on all hashes until we store 
+            # hashes in CDItem
+            if repo_name!=get_repo_name(purl):
+                continue
+            # Initialize the repo - Get or Create the git repo
+            repo = get_or_init_repo(repo_name=repo_name, work_dir=work_dir, github_org=github_org)
+            scancode_scan = data.get("content")
+            if scancode_scan:
+                add_scancode_scan(scancode_scan, purl, repo)
+                # TODO: push for every 10 commits
+
+
+def get_cd_item_by_repo_name(cd_items):
+    cd_item_by_repo_name = {}
+    for cd_item in cd_items:
+        data = cd_item.data
+        cd_url = data.get("_metadata", {}).get("url")
+        coordinate = Coordinate.from_dict(coords=str2coord(cd_url))
+        if not is_valid_coordinate(coordinate):
+            #TODO: this is a bug, we need to log it
+            continue
+        purl = coordinate.to_purl()
+        repo_name = get_repo_name(purl=purl)
+        if cd_item_by_repo_name.get(repo_name):
+            cd_item_by_repo_name[repo_name].append(cd_item)
+        else:
+            cd_item_by_repo_name[repo_name] = [cd_item]
+    return cd_item_by_repo_name
+
+
+def add_scancode_scan(scancode_scan, purl, repo):
+    """
+    Save and commit scancode scan for purl to git repo.
+    """
+    purl_data_dir = get_or_create_dir_for_purl(purl=purl, repo=repo)
+    scancode_scan_path = purl_data_dir / "scancode-toolkit-scan.json"
+    with open(scancode_scan_path, "w") as f:
+        json.dump(scancode_scan,f,indent=2)
+    repo.index.add([scancode_scan_path])
+    repo.index.commit(message=f"Add scancode-toolkit scan for {purl}")
+
+
+def is_valid_coordinate(coordinate):
+    return coordinate.type and coordinate.name
+
+
+def get_or_create_dir_for_purl(purl, repo):
+    """
+    Return a path to a directory for this purl, 
+    in this git repo.
+    """
+    purl_dir = repo.working_dir / get_purl_path(purl)
+    purl_dir.mkdir(parents=True, exist_ok=True)
+    return purl_dir
+
+def get_purl_path(purl):
+    purl_path = Path(purl.type)
+    if purl.namespace:
+        purl_path = purl_path / purl.namespace
+    return purl_path / purl.name / purl.version
+
+
+def get_repo_name(purl: PackageURL, length: int=3) -> str:
+    """
+    Return a short lower cased hash of a purl.
+    """
+    #TODO: document this function in great detail, this is a part of spec
+    purl_bytes = str(purl).encode("utf-8")
+    short_hash = sha512(purl_bytes).hexdigest()[:length]
+    return short_hash.lower()
+
+
+# def run(directory, repo_url):
+#     try:
+#         repo = Repo.clone_from(repo_url, directory)
+#     except:
+#         repo = Repo(directory)
+#         if repo.remotes.origin.fetch()[0].commit != repo.head.commit:
+#             # Pull the latest changes from the remote repository
+#             repo.remotes.origin.pull()
+
+#     store_scancode_scans_from_cd_items(work_dir = directory)
+#     RepoAdder.add_all(repo)
+#     RepoCommiter.commit(repo=repo, message="Push")
+
+
+def get_or_init_repo(repo_name: str, work_dir: Path, github_org: str= "", pull=False):
+    # TODO: Check if repo exists on remote
+    # TODO: If not exisiting on remote, create it on github_org
+    """If exists take a clone in the working directory, if repo already exists in working directory
+    then take the latest pull. Return the repo object"""
+    repo_path = work_dir / repo_name
+    if repo_path.exists():
+        return Repo(repo_path)
+    else:
+        repo = Repo.init(repo_path)
+        return repo
+
+
+def get_scan_download_url(purl:str, github_org:str, scan_file_name: str = "scancode-toolkit-scan.json"):
+    repo_name = get_repo_name(purl=purl)
+    purl_path = get_purl_path(purl)
+    return f"https://raw.githubusercontent.com/{github_org}/{repo_name}/main/{purl_path}/{scan_file_name}"
+
+
+if __name__ == "__main__":
+    work_dir = Path("")
+    store_scancode_scans_from_cd_items(work_dir=work_dir, github_org="TG1999", count=5)

--- a/clearcode/store_scans.py
+++ b/clearcode/store_scans.py
@@ -17,16 +17,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import defaultdict
 from clearcode.models import CDitem
 from clearcode.cdutils import Coordinate
 from clearcode.cdutils import str2coord
 from django.db.models import Q
 from hashlib import sha512
 import json
+import requests
 from packageurl import PackageURL
 from pathlib import Path
 from git import Repo
-
+import os
 """
 The input is a bunch of scans from ClearlyDefined and 
 the output is a bunch of git repositories with commited and 
@@ -66,12 +68,15 @@ repo_names = [hex(hash)[2:].zfill(3) for hash in range(4096)]
 def store_scancode_scans_from_cd_items(work_dir, github_org="", count=0):
     """
     Iterate over CDItem objects with scancode scans.  
-    Save and commit them in git repositories in work dir
+    Save and commit them in git repositories in work dir.
+    Process a maximum of count items and process all items if
+    count is 0
     """
     cd_items = CDitem.objects.filter(~Q(content=b''), path__contains="tool/scancode")
-    x = get_cd_item_by_repo_name(cd_items=cd_items)
-    print(x)
-    for repo_name, cd_items in x.items():
+    if count:
+        cd_items = cd_items[:count] 
+    for purl_hash, cd_items in get_cd_item_by_purl_hash(cd_items=cd_items).items():
+        commit_count = 0
         for cd_item in cd_items:
             data = cd_item.data
             cd_url = data.get("_metadata", {}).get("url")
@@ -79,21 +84,24 @@ def store_scancode_scans_from_cd_items(work_dir, github_org="", count=0):
             if not is_valid_coordinate(coordinate):
                 #TODO: this is a bug, we need to log it
                 continue
-            purl = coordinate.to_purl()
-            # temporary hack iterate on all hashes until we store 
-            # hashes in CDItem
-            if repo_name!=get_repo_name(purl):
-                continue
-            # Initialize the repo - Get or Create the git repo
-            repo = get_or_init_repo(repo_name=repo_name, work_dir=work_dir, github_org=github_org)
             scancode_scan = data.get("content")
-            if scancode_scan:
-                add_scancode_scan(scancode_scan, purl, repo)
-                # TODO: push for every 10 commits
+            if not scancode_scan:
+                continue
+            repo = get_or_init_repo(repo_name=purl_hash, work_dir=work_dir, repo_namespace=github_org, pull=False)
+            purl = coordinate.to_purl()
+            if add_scancode_scan(scancode_scan=scancode_scan, purl=purl, repo=repo):
+                commit_count += 1
+            if commit_count % 10 == 0:
+                print(".", end="")
+                origin = repo.remote(name='origin')
+                origin.push()
 
 
-def get_cd_item_by_repo_name(cd_items):
-    cd_item_by_repo_name = {}
+def get_cd_item_by_purl_hash(cd_items):
+    """
+    Return a mapping of {purl_hash: [CDItem,....]} 
+    """
+    cd_item_by_purl_hash = defaultdict(list)
     for cd_item in cd_items:
         data = cd_item.data
         cd_url = data.get("_metadata", {}).get("url")
@@ -102,28 +110,29 @@ def get_cd_item_by_repo_name(cd_items):
             #TODO: this is a bug, we need to log it
             continue
         purl = coordinate.to_purl()
-        repo_name = get_repo_name(purl=purl)
-        if cd_item_by_repo_name.get(repo_name):
-            cd_item_by_repo_name[repo_name].append(cd_item)
-        else:
-            cd_item_by_repo_name[repo_name] = [cd_item]
-    return cd_item_by_repo_name
+        purl_hash = get_purl_hash(purl=purl)
+        cd_item_by_purl_hash[purl_hash].append(cd_item)
+    return cd_item_by_purl_hash
 
 
-def add_scancode_scan(scancode_scan, purl, repo):
+def add_scancode_scan(repo, purl, scancode_scan):
     """
     Save and commit scancode scan for purl to git repo.
+    Return true if we commited else false
     """
     purl_data_dir = get_or_create_dir_for_purl(purl=purl, repo=repo)
     scancode_scan_path = purl_data_dir / "scancode-toolkit-scan.json"
     with open(scancode_scan_path, "w") as f:
         json.dump(scancode_scan,f,indent=2)
-    repo.index.add([scancode_scan_path])
-    repo.index.commit(message=f"Add scancode-toolkit scan for {purl}")
+
+    if repo.is_dirty():
+        repo.index.add([scancode_scan_path])
+        repo.index.commit(message=f"Add scancode-toolkit scan for {purl}")
+        return True
 
 
 def is_valid_coordinate(coordinate):
-    return coordinate.type and coordinate.name
+    return coordinate.type and coordinate.name and coordinate.version
 
 
 def get_or_create_dir_for_purl(purl, repo):
@@ -142,7 +151,7 @@ def get_purl_path(purl):
     return purl_path / purl.name / purl.version
 
 
-def get_repo_name(purl: PackageURL, length: int=3) -> str:
+def get_purl_hash(purl: PackageURL, length: int=3) -> str:
     """
     Return a short lower cased hash of a purl.
     """
@@ -152,38 +161,76 @@ def get_repo_name(purl: PackageURL, length: int=3) -> str:
     return short_hash.lower()
 
 
-# def run(directory, repo_url):
-#     try:
-#         repo = Repo.clone_from(repo_url, directory)
-#     except:
-#         repo = Repo(directory)
-#         if repo.remotes.origin.fetch()[0].commit != repo.head.commit:
-#             # Pull the latest changes from the remote repository
-#             repo.remotes.origin.pull()
-
-#     store_scancode_scans_from_cd_items(work_dir = directory)
-#     RepoAdder.add_all(repo)
-#     RepoCommiter.commit(repo=repo, message="Push")
-
-
-def get_or_init_repo(repo_name: str, work_dir: Path, github_org: str= "", pull=False):
-    # TODO: Check if repo exists on remote
-    # TODO: If not exisiting on remote, create it on github_org
-    """If exists take a clone in the working directory, if repo already exists in working directory
-    then take the latest pull. Return the repo object"""
+def get_or_init_repo(repo_name: str, work_dir: Path, repo_namespace: str= "", pull=False):
+    """
+    Return a repo object for repo name and namespace 
+    and store it in the work dir. Clone if it does not 
+    exist optionally take the latest pull if it does exist.
+    """
+    # TODO: Manage org repo name
+    # MAYBE: CREATE ALL THE REPOS AT A TIME AND CLONE THEM LOCALLY
+    if repo_name not in get_github_repos(user_name="TG1999"):
+        repo_url = create_github_repo(repo_name=repo_name)
     repo_path = work_dir / repo_name
     if repo_path.exists():
-        return Repo(repo_path)
+        repo = Repo(repo_path)
+        if pull:
+            repo.origin.pull()
     else:
-        repo = Repo.init(repo_path)
-        return repo
+        repo = Repo.clone_from(repo_url, repo_path)
+    return repo
 
 
-def get_scan_download_url(purl:str, github_org:str, scan_file_name: str = "scancode-toolkit-scan.json"):
-    repo_name = get_repo_name(purl=purl)
+def get_scan_download_url(namespace:str, purl:str, scan_file_name: str = "scancode-toolkit-scan.json"):
+    purl_hash = get_purl_hash(purl=purl)
     purl_path = get_purl_path(purl)
-    return f"https://raw.githubusercontent.com/{github_org}/{repo_name}/main/{purl_path}/{scan_file_name}"
+    return f"https://raw.githubusercontent.com/{namespace}/{purl_hash}/main/{purl_path}/{scan_file_name}"
 
+
+def create_github_repo(repo_name, token=os.getenv("GH_TOKEN")):
+    headers = {
+        'Authorization': f'token {token}',
+        'Accept': 'application/vnd.github.v3+json'
+    }
+
+    data = {
+        'name': repo_name,
+    }
+
+    url = 'https://api.github.com/user/repos'
+
+    response = requests.post(url, headers=headers, json=data)
+
+    if response.status_code == 201:
+        print(f"Repository '{repo_name}' created successfully!")
+    else:
+        print(f"Failed to create repository. Status code: {response.status_code}")
+        print(response.text)
+
+
+def get_github_repos(user_name, token=os.getenv("GH_TOKEN")):
+    """
+    Yield full repo names for a user or org name, use the optional ``token`` if provided.
+    Full repo name is in the form user or org name / repo name
+    """
+    headers = {
+        'Accept': 'application/vnd.github.v3+json'
+    }
+    if token:
+        headers['Authorization'] = f'token {token}'
+
+    url = f'https://api.github.com/users/{user_name}/repos'
+    response = requests.get(url, headers=headers)
+
+    # TODO: We need have a way to handle failures from GH API
+    if not response.status_code == 200:
+        raise Exception(f"HTTP {response.status_code}: Failed to get repos for {user_name}")
+
+    data = response.json()
+    for repo_data in data:
+        full_repo_name = repo_data.get("full_name")
+        if full_repo_name:
+            yield full_repo_name
 
 if __name__ == "__main__":
     work_dir = Path("")

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ ftputil==5.0.4
 fusepy==3.0.1
 gemfileparser2==0.9.3
 gitdb==4.0.11
-GitPython==3.1.40
+GitPython==3.1.43
 go-inspector==0.2.2
 gunicorn==22.0.0
 html5lib==1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ ftputil==5.0.4
 fusepy==3.0.1
 gemfileparser2==0.9.3
 gitdb==4.0.11
-GitPython==3.1.43
+GitPython==3.1.40
 go-inspector==0.2.2
 gunicorn==22.0.0
 html5lib==1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ install_requires =
     purl2vcs == 1.0.1
     univers == 30.11.0
     scancodeio @ git+https://github.com/nexB/scancode.io.git@07b48c0224f5c2ad1b2972b693702ef685f16c98
-    gitpython == 3.1.40
+    gitpython == 3.1.43
 setup_requires = setuptools_scm[toml] >= 4
 
 python_requires = >=3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ install_requires =
     purl2vcs == 1.0.1
     univers == 30.11.0
     scancodeio @ git+https://github.com/nexB/scancode.io.git@07b48c0224f5c2ad1b2972b693702ef685f16c98
+    gitpython == 3.1.40
 setup_requires = setuptools_scm[toml] >= 4
 
 python_requires = >=3.8


### PR DESCRIPTION
This PR allows to store scans locally using a PURL hash-based distribution of scans in multiple directories to avoid stressing file systems with too many files in one directory.
The goal is also to store these in Git repositories