### PR TITLE
263 remove scan and fingerprint package from entrypoints

### DIFF
--- a/matchcode-toolkit/CHANGELOG.rst
+++ b/matchcode-toolkit/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+v2.0.0
+------
+
+*2023-12-18* -- Remove ``ScanAndFingerprintPackage`` pipeline from matchcode-toolkit's entry points. (https://github.com/nexB/purldb/issues/263)
+
 v1.1.3
 ------
 

--- a/matchcode-toolkit/CHANGELOG.rst
+++ b/matchcode-toolkit/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+v2.0.1
+------
+
+*2023-12-19* -- Update ``ScanAndFingerprintPackage`` pipeline with updates from the upstream ``ScanPackage`` pipeline from scancode.io
+
 v2.0.0
 ------
 

--- a/matchcode-toolkit/pyproject.toml
+++ b/matchcode-toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "matchcode-toolkit"
-version = "2.0.0"
+version = "2.0.1"
 
 [build-system]
 requires = ["setuptools >= 50", "wheel", "setuptools_scm[toml] >= 6"]

--- a/matchcode-toolkit/pyproject.toml
+++ b/matchcode-toolkit/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "matchcode-toolkit"
-version = "1.1.3"
+version = "2.0.0"
 
 [build-system]
 requires = ["setuptools >= 50", "wheel", "setuptools_scm[toml] >= 6"]

--- a/matchcode-toolkit/setup.cfg
+++ b/matchcode-toolkit/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = matchcode-toolkit
-version = 1.1.3
+version = 2.0.0
 license = Apache-2.0
 
 # description must be on ONE line https://github.com/pypa/setuptools/issues/1390
@@ -65,6 +65,3 @@ docs =
 [options.entry_points]
 scancode_post_scan =
     fingerprint = matchcode_toolkit.plugin_fingerprint:Fingerprint
-
-scancodeio_pipelines =
-    scan_and_fingerprint_package = matchcode_toolkit.pipelines.scan_and_fingerprint_package:ScanAndFingerprintPackage

--- a/matchcode-toolkit/setup.cfg
+++ b/matchcode-toolkit/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = matchcode-toolkit
-version = 2.0.0
+version = 2.0.1
 license = Apache-2.0
 
 # description must be on ONE line https://github.com/pypa/setuptools/issues/1390

--- a/matchcode-toolkit/src/matchcode_toolkit/pipelines/scan_and_fingerprint_package.py
+++ b/matchcode-toolkit/src/matchcode_toolkit/pipelines/scan_and_fingerprint_package.py
@@ -26,8 +26,8 @@ from scanpipe.pipes import matchcode
 
 class ScanAndFingerprintPackage(ScanPackage):
     """
-    Scan a single package archive with ScanCode-toolkit, then calculate the
-    directory fingerprints of the codebase.
+    Scan a single package file or package archive with ScanCode-toolkit, then
+    calculate the directory fingerprints of the codebase.
 
     The output is a summary of the scan results in JSON format.
     """
@@ -35,10 +35,10 @@ class ScanAndFingerprintPackage(ScanPackage):
     @classmethod
     def steps(cls):
         return (
-            cls.get_package_archive_input,
-            cls.collect_archive_information,
-            cls.extract_archive_to_codebase_directory,
-            cls.run_scancode,
+            cls.get_package_input,
+            cls.collect_input_information,
+            cls.extract_input_to_codebase_directory,
+            cls.run_scan,
             cls.load_inventory_from_toolkit_scan,
             cls.fingerprint_codebase,
             cls.make_summary_from_scan_results,

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ install_requires =
     rubymarshal == 1.0.3
     scancode-toolkit[full] == 32.0.8
     urlpy == 0.5
-    matchcode-toolkit >= 1.1.1
+    matchcode-toolkit >= 2.0.1
     univers == 30.11.0
 setup_requires = setuptools_scm[toml] >= 4
 


### PR DESCRIPTION
This PR updates matchcode-toolkit, following the changes made to the ScanPackage pipeline from scancode.io