### PR TITLE
Add golang purl service

### DIFF
--- a/packagedb/serializers.py
+++ b/packagedb/serializers.py
@@ -414,3 +414,11 @@ class PurlValidateResponseSerializer(Serializer):
 class PurlValidateSerializer(Serializer):
     purl = CharField(required=True)
     check_existence = BooleanField(required=False, default=False)
+
+
+class GoLangPurlSerializer(Serializer):
+    go_package = CharField(required=True)
+
+
+class GoLangPurlResponseSerializer(Serializer):
+    golang_purl = CharField()

--- a/packagedb/serializers.py
+++ b/packagedb/serializers.py
@@ -421,4 +421,4 @@ class GoLangPurlSerializer(Serializer):
 
 
 class GoLangPurlResponseSerializer(Serializer):
-    golang_purl = CharField()
+    package_url = CharField()

--- a/packagedb/tests/test_api.py
+++ b/packagedb/tests/test_api.py
@@ -1186,4 +1186,4 @@ class ToGolangPurlTestCase(TestCase):
     def test_to_golang_purl(self):
         response = self.client.get("/api/to_purl/go", data={"go_package": "github.com/gorilla/mux@v1.7.3"}, follow=True)
         expected = "pkg:golang/github.com/gorilla/mux%40v1.7.3"
-        self.assertEqual(expected, response.data["golang_purl"])
+        self.assertEqual(expected, response.data["package_url"])

--- a/packagedb/tests/test_api.py
+++ b/packagedb/tests/test_api.py
@@ -1186,4 +1186,4 @@ class ToGolangPurlTestCase(TestCase):
     def test_to_golang_purl(self):
         response = self.client.get(f"/api/to/golang/purl?go_package=github.com/gorilla/mux@v1.7.3")
         expected = "pkg:golang/github.com/gorilla/mux@1.7.3",
-        self.assertEqual(expected, response["golang_package"])
+        self.assertEqual(expected, response["golang_purl"])

--- a/packagedb/tests/test_api.py
+++ b/packagedb/tests/test_api.py
@@ -1184,6 +1184,6 @@ class PurlValidateApiTestCase(TestCase):
 class ToGolangPurlTestCase(TestCase):
 
     def test_to_golang_purl(self):
-        response = self.client.get(f"/api/to_purl/go?go_package=github.com/gorilla/mux@v1.7.3")
-        expected = "pkg:golang/github.com/gorilla/mux@1.7.3",
-        self.assertEqual(expected, response["golang_purl"])
+        response = self.client.get("/api/to_purl/go", data={"go_package": "github.com/gorilla/mux@v1.7.3"}, follow=True)
+        expected = "pkg:golang/github.com/gorilla/mux%40v1.7.3"
+        self.assertEqual(expected, response.data["golang_purl"])

--- a/packagedb/tests/test_api.py
+++ b/packagedb/tests/test_api.py
@@ -1184,6 +1184,6 @@ class PurlValidateApiTestCase(TestCase):
 class ToGolangPurlTestCase(TestCase):
 
     def test_to_golang_purl(self):
-        response = self.client.get(f"/api/to/golang/purl?go_package=github.com/gorilla/mux@v1.7.3")
+        response = self.client.get(f"/api/to_purl/go?go_package=github.com/gorilla/mux@v1.7.3")
         expected = "pkg:golang/github.com/gorilla/mux@1.7.3",
         self.assertEqual(expected, response["golang_purl"])

--- a/packagedb/tests/test_api.py
+++ b/packagedb/tests/test_api.py
@@ -1179,3 +1179,11 @@ class PurlValidateApiTestCase(TestCase):
         }
 
         self.assertAlmostEquals(expected, response1.data)
+
+
+class ToGolangPurlTestCase(TestCase):
+
+    def test_to_golang_purl(self):
+        response = self.client.get(f"/api/to/golang/purl?go_package=github.com/gorilla/mux@v1.7.3")
+        expected = "pkg:golang/github.com/gorilla/mux@1.7.3",
+        self.assertEqual(expected, response["golang_package"])

--- a/packagedb/to_purl.py
+++ b/packagedb/to_purl.py
@@ -64,7 +64,7 @@ class GolangPurlViewSet(viewsets.ViewSet):
                 {"errors": "`@` is not supported either in import or go.mod string"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        response["package_url"] = purl
+        response["package_url"] = str(purl)
         serializer = GoLangPurlResponseSerializer(
             response, context={"request": request}
         )

--- a/packagedb/to_purl.py
+++ b/packagedb/to_purl.py
@@ -21,7 +21,7 @@ from rest_framework import routers
 
 @extend_schema(
     parameters=[
-        OpenApiParameter("go_package", str, "query", description="PackageURL"),
+        OpenApiParameter("go_package", str, "query", description="go import package"),
     ],
     responses={200: GoLangPurlResponseSerializer()},
 )

--- a/packagedb/to_purl.py
+++ b/packagedb/to_purl.py
@@ -26,6 +26,10 @@ from rest_framework import routers
     responses={200: GoLangPurlResponseSerializer()},
 )
 class GolangPurlViewSet(viewsets.ViewSet):
+    """
+    Return a ``golang_purl`` from a standard go import string 
+    ``go_package``.
+    """
 
     serializer_class = GoLangPurlSerializer
 

--- a/packagedb/to_purl.py
+++ b/packagedb/to_purl.py
@@ -30,7 +30,7 @@ class GolangPurlViewSet(viewsets.ViewSet):
     serializer_class = GoLangPurlSerializer
 
     def get_view_name(self):
-        return "Validate PURL"
+        return "GoLang purl"
 
     def list(self, request):
         serializer = self.serializer_class(data=request.query_params)

--- a/packagedb/to_purl.py
+++ b/packagedb/to_purl.py
@@ -27,8 +27,14 @@ from rest_framework import routers
 )
 class GolangPurlViewSet(viewsets.ViewSet):
     """
-    Return a ``golang_purl`` from a standard go import string 
-    ``go_package``.
+    Return a ``golang_purl`` from a standard go import string or 
+    a go.mod string ``go_package``.
+    For example:
+    >>> get_golang_purl("github.com/gorilla/mux v1.8.1")
+    "pkg:golang/github.com/gorilla/mux@v1.8.1"
+    >>> # This is an example of go.mod string
+    >>> get_golang_purl("github.com/gorilla/mux")
+    "pkg:golang/github.com/gorilla/mux"
     """
 
     serializer_class = GoLangPurlSerializer
@@ -48,7 +54,7 @@ class GolangPurlViewSet(viewsets.ViewSet):
         validated_data = serializer.validated_data
         go_import = validated_data.get("go_package")
         purl = get_golang_purl(go_import)
-        response["golang_purl"] = purl
+        response["package_url"] = purl
         serializer = GoLangPurlResponseSerializer(
             response, context={"request": request}
         )

--- a/packagedb/to_purl.py
+++ b/packagedb/to_purl.py
@@ -1,0 +1,54 @@
+#
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# purldb is a trademark of nexB Inc.
+# SPDX-License-Identifier: Apache-2.0
+# See http://www.apache.org/licenses/LICENSE-2.0 for the license text.
+# See https://github.com/nexB/purldb for support or download.
+# See https://aboutcode.org for more information about nexB OSS projects.
+#
+
+from django.db import router
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+from packageurl.utils import get_golang_purl
+from rest_framework import status
+from rest_framework import viewsets
+from rest_framework.response import Response
+
+from packagedb.serializers import GoLangPurlResponseSerializer
+from packagedb.serializers import GoLangPurlSerializer
+from rest_framework import routers
+
+
+@extend_schema(
+    parameters=[
+        OpenApiParameter("go_package", str, "query", description="PackageURL"),
+    ],
+    responses={200: GoLangPurlResponseSerializer()},
+)
+class GolangPurlViewSet(viewsets.ViewSet):
+
+    serializer_class = GoLangPurlSerializer
+
+    def get_view_name(self):
+        return "Validate PURL"
+
+    def list(self, request):
+        serializer = self.serializer_class(data=request.query_params)
+        response = {}
+
+        if not serializer.is_valid():
+            return Response(
+                {"errors": serializer.errors}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        validated_data = serializer.validated_data
+        go_import = validated_data.get("go_package")
+        purl = get_golang_purl(go_import)
+        response["golang_purl"] = purl
+        serializer = GoLangPurlResponseSerializer(
+            response, context={"request": request}
+        )
+        return Response(serializer.data)
+
+api_to_purl_router = routers.DefaultRouter()
+api_to_purl_router.register("go", GolangPurlViewSet, "go")

--- a/packagedb/to_purl.py
+++ b/packagedb/to_purl.py
@@ -29,13 +29,16 @@ class GolangPurlViewSet(viewsets.ViewSet):
     """
     Return a ``golang_purl`` from a standard go import string or
     a go.mod string ``go_package``.
+    
     For example:
-    >>> get_golang_purl("github.com/gorilla/mux v1.8.1")
-    "pkg:golang/github.com/gorilla/mux@v1.8.1"
-    >>> # This is an example of go.mod string `package version`
-    >>> get_golang_purl("github.com/gorilla/mux")
-    "pkg:golang/github.com/gorilla/mux"
-    >>> #This is an example a go import string `package`
+
+        >>> get_golang_purl("github.com/gorilla/mux v1.8.1")
+        "pkg:golang/github.com/gorilla/mux@v1.8.1"
+        >>> # This is an example of go.mod string `package version`
+        >>> 
+        >>> get_golang_purl("github.com/gorilla/mux")
+        "pkg:golang/github.com/gorilla/mux"
+        >>> #This is an example a go import string `package`
     """
 
     serializer_class = GoLangPurlSerializer

--- a/packagedb/to_purl.py
+++ b/packagedb/to_purl.py
@@ -32,9 +32,10 @@ class GolangPurlViewSet(viewsets.ViewSet):
     For example:
     >>> get_golang_purl("github.com/gorilla/mux v1.8.1")
     "pkg:golang/github.com/gorilla/mux@v1.8.1"
-    >>> # This is an example of go.mod string
+    >>> # This is an example of go.mod string `package version`
     >>> get_golang_purl("github.com/gorilla/mux")
     "pkg:golang/github.com/gorilla/mux"
+    >>> #This is an example a go import string `package`
     """
 
     serializer_class = GoLangPurlSerializer

--- a/packagedb/to_purl.py
+++ b/packagedb/to_purl.py
@@ -57,9 +57,6 @@ class GolangPurlViewSet(viewsets.ViewSet):
         try:
             purl = get_golang_purl(go_import)
         except:
-            serializer = GoLangPurlResponseSerializer(
-                response, context={"request": request}
-            )
             return Response(
                 {"errors": "`@` is not supported either in import or go.mod string"},
                 status=status.HTTP_400_BAD_REQUEST,

--- a/purldb_project/urls.py
+++ b/purldb_project/urls.py
@@ -25,6 +25,7 @@ from matchcode.api import ExactFileIndexViewSet
 from matchcode.api import ExactPackageArchiveIndexViewSet
 from minecode.api import PriorityResourceURIViewSet
 from packagedb.api import PurlValidateViewSet
+from packagedb.to_purl import api_to_purl_router
 from packagedb.api import CollectViewSet
 from drf_spectacular.views import SpectacularAPIView
 from drf_spectacular.views import SpectacularSwaggerView
@@ -51,6 +52,7 @@ urlpatterns = [
         TemplateView.as_view(template_name='robots.txt', content_type='text/plain'),
     ),
     path('api/', include((api_router.urls, 'api'))),
+    path('api/to', include((api_to_purl_router.urls, 'api_to'))),
     path("", RedirectView.as_view(url="api/")),
     path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
     path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),

--- a/purldb_project/urls.py
+++ b/purldb_project/urls.py
@@ -52,7 +52,7 @@ urlpatterns = [
         TemplateView.as_view(template_name='robots.txt', content_type='text/plain'),
     ),
     path('api/', include((api_router.urls, 'api'))),
-    path('api/to', include((api_to_purl_router.urls, 'api_to'))),
+    path('api/to_purl/', include((api_to_purl_router.urls, 'api_to'))),
     path("", RedirectView.as_view(url="api/")),
     path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
     path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,7 +74,7 @@ natsort==8.2.0
 normality==2.5.0
 openpyxl==3.1.2
 packagedcode-msitools==0.101.210706
-packageurl-python==0.13.4
+packageurl-python==0.14.0
 packaging==23.2
 packvers==21.5
 parameter-expansion-patched==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,7 +74,7 @@ natsort==8.2.0
 normality==2.5.0
 openpyxl==3.1.2
 packagedcode-msitools==0.101.210706
-packageurl-python==0.14.0
+packageurl-python==0.15.0
 packaging==23.2
 packvers==21.5
 parameter-expansion-patched==0.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     jawa == 2.2.0
     markdown == 3.5.1
     natsort == 8.2.0
-    packageurl-python == 0.14.0
+    packageurl-python == 0.15.0
     psycopg[binary]==3.1.17
     PyGithub == 1.56
     reppy2 == 0.3.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     jawa == 2.2.0
     markdown == 3.5.1
     natsort == 8.2.0
-    packageurl-python == 0.13.4
+    packageurl-python == 0.14.0
     psycopg[binary]==3.1.17
     PyGithub == 1.56
     reppy2 == 0.3.6


### PR DESCRIPTION
Fixes: https://github.com/nexB/purldb/issues/259

Added a `/api/to_purl/go` endpoint to get a golang purl from a go import string or a package string in go.mod file