### PR TITLE
Add support for on demand addon_pipeline in `/api/collect` endpoints

### DIFF
--- a/minecode/model_utils.py
+++ b/minecode/model_utils.py
@@ -32,6 +32,14 @@ DEFAULT_PIPELINES = (
     'fingerprint_codebase',
 )
 
+# These are the list of supported addon pipelines to run when we scan a Package for
+# indexing.
+SUPPORTED_ADDON_PIPELINES = (
+    'collect_symbols',
+    'collect_source_strings',
+    'inspect_elf_binaries',
+)
+
 
 def add_package_to_scan_queue(package, pipelines=DEFAULT_PIPELINES, reindex_uri=False, priority=0):
     """

--- a/minecode/model_utils.py
+++ b/minecode/model_utils.py
@@ -30,9 +30,6 @@ logger.setLevel(logging.INFO)
 DEFAULT_PIPELINES = (
     'scan_single_package',
     'fingerprint_codebase',
-    'collect_symbols',
-    'collect_source_strings',
-    'inspect_elf_binaries',
 )
 
 

--- a/minecode/tests/test_conan.py
+++ b/minecode/tests/test_conan.py
@@ -98,7 +98,7 @@ class ConanPriorityQueueTests(JsonBasedTesting, TestCase):
         package_count = packagedb.models.Package.objects.all().count()
         self.assertEqual(package_count, 0)
 
-        conan.map_conan_package(self.package_url1)
+        conan.map_conan_package(self.package_url1, ('test_pipelines'))
         package_count = packagedb.models.Package.objects.all().count()
         self.assertEqual(package_count, 1)
         package = packagedb.models.Package.objects.all().first()

--- a/minecode/tests/test_generic.py
+++ b/minecode/tests/test_generic.py
@@ -49,7 +49,7 @@ class GenericPriorityQueueTests(JsonBasedTesting, DjangoTestCase):
 
         purl = 'pkg:generic/test@1.0.0?download_url=http://example.com/test.tar.gz'
         package_url = PackageURL.from_string(purl)
-        error_msg = generic.map_generic_package(package_url)
+        error_msg = generic.map_generic_package(package_url, ('test_pipeline'))
 
         self.assertEqual('', error_msg)
         package_count = Package.objects.all().count()
@@ -65,7 +65,7 @@ class GenericPriorityQueueTests(JsonBasedTesting, DjangoTestCase):
         self.assertEqual(0, package_count)
 
         purl = PackageURL.from_string("pkg:generic/udhcp@0.9.1")
-        error_msg = generic.map_fetchcode_supported_package(purl)
+        error_msg = generic.map_fetchcode_supported_package(purl, ('test_pipeline'))
 
         self.assertEqual('', error_msg)
         package_count = Package.objects.all().count()

--- a/minecode/tests/test_maven.py
+++ b/minecode/tests/test_maven.py
@@ -720,7 +720,7 @@ class MavenPriorityQueueTests(JsonBasedTesting, DjangoTestCase):
         package_count = packagedb.models.Package.objects.all().count()
         self.assertEqual(0, package_count)
         package_url = PackageURL.from_string(self.scan_package.purl)
-        maven_visitor.map_maven_package(package_url, packagedb.models.PackageContentType.BINARY)
+        maven_visitor.map_maven_package(package_url, packagedb.models.PackageContentType.BINARY, ('test_pipeline'))
         package_count = packagedb.models.Package.objects.all().count()
         self.assertEqual(1, package_count)
         package = packagedb.models.Package.objects.all().first()
@@ -732,7 +732,7 @@ class MavenPriorityQueueTests(JsonBasedTesting, DjangoTestCase):
         self.assertEqual(0, package_count)
         custom_repo_purl = "pkg:maven/org.eclipse.core/runtime@20070801?repository_url=https://packages.atlassian.com/mvn/maven-atlassian-external/"
         package_url = PackageURL.from_string(custom_repo_purl)
-        maven_visitor.map_maven_package(package_url, packagedb.models.PackageContentType.BINARY)
+        maven_visitor.map_maven_package(package_url, packagedb.models.PackageContentType.BINARY, ('test_pipeline'))
         package_count = packagedb.models.Package.objects.all().count()
         self.assertEqual(1, package_count)
         package = packagedb.models.Package.objects.all().first()

--- a/minecode/tests/test_npm.py
+++ b/minecode/tests/test_npm.py
@@ -199,7 +199,7 @@ class NpmPriorityQueueTests(JsonBasedTesting, DjangoTestCase):
         package_count = packagedb.models.Package.objects.all().count()
         self.assertEqual(0, package_count)
         package_url = PackageURL.from_string(self.scan_package.purl)
-        npm.map_npm_package(package_url)
+        npm.map_npm_package(package_url, ('test_pipeline'))
         package_count = packagedb.models.Package.objects.all().count()
         self.assertEqual(1, package_count)
         package = packagedb.models.Package.objects.all().first()

--- a/minecode/visitors/github.py
+++ b/minecode/visitors/github.py
@@ -186,7 +186,7 @@ def json_serial_date_obj(obj):
 # Indexing GitHub PURLs requires a GitHub API token.
 # Please add your GitHub API key to the `.env` file, for example: `GH_TOKEN=your-github-api`.
 @priority_router.route('pkg:github/.*')
-def process_request_dir_listed(purl_str):
+def process_request_dir_listed(purl_str, **kwargs):
     """
     Process `priority_resource_uri` containing a GitHub Package URL (PURL).
 
@@ -194,13 +194,17 @@ def process_request_dir_listed(purl_str):
     https://github.com/nexB/fetchcode and using it to create a new
     PackageDB entry. The package is then added to the scan queue afterwards.
     """
+    from minecode.model_utils import DEFAULT_PIPELINES
+
+    addon_pipelines = kwargs.get('addon_pipelines', [])
+    pipelines = DEFAULT_PIPELINES + tuple(addon_pipelines)
     try:
         package_url = PackageURL.from_string(purl_str)
     except ValueError as e:
         error = f"error occurred when parsing {purl_str}: {e}"
         return error
 
-    error_msg = map_fetchcode_supported_package(package_url)
+    error_msg = map_fetchcode_supported_package(package_url, pipelines)
 
     if error_msg:
         return error_msg

--- a/minecode/visitors/gnu.py
+++ b/minecode/visitors/gnu.py
@@ -22,7 +22,7 @@ logger.setLevel(logging.INFO)
 
 
 @priority_router.route("pkg:gnu/.*")
-def process_request(purl_str):
+def process_request(purl_str, **kwargs):
     """
     Process `priority_resource_uri` containing a GNU Package URL (PURL) as a
     URI.
@@ -31,11 +31,16 @@ def process_request(purl_str):
     https://github.com/nexB/fetchcode and using it to create a new
     PackageDB entry. The package is then added to the scan queue afterwards.
     """
+    from minecode.model_utils import DEFAULT_PIPELINES
+
+    addon_pipelines = kwargs.get('addon_pipelines', [])
+    pipelines = DEFAULT_PIPELINES + tuple(addon_pipelines)
+
     package_url = PackageURL.from_string(purl_str)
     if not package_url.version:
         return
 
-    error_msg = map_fetchcode_supported_package(package_url)
+    error_msg = map_fetchcode_supported_package(package_url, pipelines)
 
     if error_msg:
         return error_msg

--- a/minecode/visitors/npm.py
+++ b/minecode/visitors/npm.py
@@ -127,7 +127,7 @@ def get_package_json(namespace, name, version):
         logger.error(f"HTTP error occurred: {err}")
 
 
-def map_npm_package(package_url):
+def map_npm_package(package_url, pipelines):
     """
     Add a npm `package_url` to the PackageDB.
 
@@ -156,13 +156,13 @@ def map_npm_package(package_url):
 
     # Submit package for scanning
     if db_package:
-        add_package_to_scan_queue(db_package)
+        add_package_to_scan_queue(db_package, pipelines)
 
     return error
 
 
 @priority_router.route('pkg:npm/.*')
-def process_request(purl_str):
+def process_request(purl_str, *kwargs):
     """
     Process `priority_resource_uri` containing a npm Package URL (PURL) as a
     URI.
@@ -171,11 +171,16 @@ def process_request(purl_str):
     using it to create a new PackageDB entry. The package is then added to the
     scan queue afterwards.
     """
+    from minecode.model_utils import DEFAULT_PIPELINES
+    
+    addon_pipelines = kwargs.get('addon_pipelines', [])
+    pipelines = DEFAULT_PIPELINES + tuple(addon_pipelines)
+
     package_url = PackageURL.from_string(purl_str)
     if not package_url.version:
         return
 
-    error_msg = map_npm_package(package_url)
+    error_msg = map_npm_package(package_url, pipelines)
 
     if error_msg:
         return error_msg

--- a/minecode/visitors/npm.py
+++ b/minecode/visitors/npm.py
@@ -162,7 +162,7 @@ def map_npm_package(package_url, pipelines):
 
 
 @priority_router.route('pkg:npm/.*')
-def process_request(purl_str, *kwargs):
+def process_request(purl_str, **kwargs):
     """
     Process `priority_resource_uri` containing a npm Package URL (PURL) as a
     URI.

--- a/minecode/visitors/openssl.py
+++ b/minecode/visitors/openssl.py
@@ -94,7 +94,7 @@ class OpenSSLVisitor(HttpVisitor):
 # Indexing OpenSSL PURLs requires a GitHub API token.
 # Please add your GitHub API key to the `.env` file, for example: `GH_TOKEN=your-github-api`.
 @priority_router.route('pkg:openssl/openssl@.*')
-def process_request_dir_listed(purl_str):
+def process_request_dir_listed(purl_str, **kwargs):
     """
     Process `priority_resource_uri` containing a OpenSSL Package URL (PURL)
     supported by fetchcode.
@@ -103,13 +103,18 @@ def process_request_dir_listed(purl_str):
     https://github.com/nexB/fetchcode and using it to create a new
     PackageDB entry. The package is then added to the scan queue afterwards.
     """
+    from minecode.model_utils import DEFAULT_PIPELINES
+    
+    addon_pipelines = kwargs.get('addon_pipelines', [])
+    pipelines = DEFAULT_PIPELINES + tuple(addon_pipelines)
+
     try:
         package_url = PackageURL.from_string(purl_str)
     except ValueError as e:
         error = f"error occurred when parsing {purl_str}: {e}"
         return error
 
-    error_msg = map_fetchcode_supported_package(package_url)
+    error_msg = map_fetchcode_supported_package(package_url, pipelines)
 
     if error_msg:
         return error_msg

--- a/packagedb/api.py
+++ b/packagedb/api.py
@@ -53,7 +53,7 @@ from packagedb.models import Resource
 from packagedb.package_managers import VERSION_API_CLASSES_BY_PACKAGE_TYPE
 from packagedb.package_managers import get_api_package_name
 from packagedb.package_managers import get_version_fetcher
-from packagedb.serializers import CollectPackageSerializer
+from packagedb.serializers import CollectPackageSerializer, is_supported_addon_pipeline
 from packagedb.serializers import DependentPackageSerializer
 from packagedb.serializers import IndexPackagesResponseSerializer
 from packagedb.serializers import IndexPackagesSerializer
@@ -856,7 +856,7 @@ class CollectViewSet(viewsets.ViewSet):
                 purl = package['purl']
                 kwargs = dict()
                 if addon_pipelines := package.get('source_purl'):
-                    kwargs["addon_pipelines"] = addon_pipelines
+                    kwargs["addon_pipelines"] = [pipe for pipe in addon_pipelines if is_supported_addon_pipeline(pipe)]
                 lookups = purl_to_lookups(purl)
                 packages = Package.objects.filter(**lookups)
                 if packages.count() > 0:
@@ -883,7 +883,7 @@ class CollectViewSet(viewsets.ViewSet):
                     if source_purl := package.get('source_purl'):
                         extra_fields["source_uri"] = source_purl
                     if addon_pipelines := package.get('addon_pipelines'):
-                        extra_fields["addon_pipelines"] = addon_pipelines
+                        extra_fields["addon_pipelines"] = [pipe for pipe in addon_pipelines if is_supported_addon_pipeline(pipe)]
                     priority_resource_uri = PriorityResourceURI.objects.insert(purl, **extra_fields)
                     if priority_resource_uri:
                         queued_packages.append(purl)

--- a/packagedb/api.py
+++ b/packagedb/api.py
@@ -679,7 +679,14 @@ class CollectViewSet(viewsets.ViewSet):
     Return Package data for the purl passed in the `purl` query parameter.
 
     If the package does not exist, we will fetch the Package data and return
-    it in the same request.
+    it in the same request.  
+    Optionally, provide the list of addon_pipelines
+    to run on the package. Find all addon pipelines [here.](https://scancodeio.readthedocs.io/en/latest/built-in-pipelines.html)
+
+    **Example:**
+
+            /api/collect/?purl=pkg:npm/foo@1.2.3&addon_pipelines=collect_symbols&addon_pipelines=inspect_elf_binaries
+
 
     **Note:** Use `Index packages` for bulk indexing/reindexing of packages.
     """
@@ -752,7 +759,10 @@ class CollectViewSet(viewsets.ViewSet):
         """
         Take a list of `packages` (where each item is a dictionary containing either PURL
         or versionless PURL along with vers range, optionally with source package PURL)
-        and index it.
+        and index it.  
+        Also each package can have list of `addon_pipelines` to run on the package.  
+        Find all addon pipelines [here.](https://scancodeio.readthedocs.io/en/latest/built-in-pipelines.html)
+
 
         If `reindex` flag is True then existing package will be rescanned, if `reindex_set`
         is True then all the package in the same set will be rescanned.
@@ -768,17 +778,20 @@ class CollectViewSet(viewsets.ViewSet):
                         {
                             "purl": "pkg:npm/less@1.0.32",
                             "vers": null,
-                            "source_purl": None
+                            "source_purl": None,
+                            "addon_pipelines": ['collect_symbols']
                         },
                         {
                             "purl": "pkg:npm/less",
                             "vers": "vers:npm/>=1.1.0|<=1.1.4",
-                            "source_purl": None
+                            "source_purl": None,
+                            "addon_pipelines": None
                         },
                         {
                             "purl": "pkg:npm/foobar",
                             "vers": null,
-                            "source_purl": None
+                            "source_purl": None,
+                            "addon_pipelines": ['inspect_elf_binaries', 'collect_symbols']
                         }
                     ]
                     "reindex": true,

--- a/packagedb/models.py
+++ b/packagedb/models.py
@@ -620,15 +620,19 @@ class Package(
         if sorted_versions:
             return sorted_versions[-1]
 
-    def reindex(self):
+    def reindex(self, **kwargs):
         """
         Trigger another scan of this Package, where a new ScannableURI is
         created for this Package. The fingerprints and Resources associated with
         this Package are deleted and recreated from the updated scan data.
         """
         from minecode.model_utils import add_package_to_scan_queue
+        from minecode.model_utils import DEFAULT_PIPELINES
 
-        add_package_to_scan_queue(self, reindex_uri=True, priority=100)
+        addon_pipelines = kwargs.get('addon_pipelines', [])
+        pipelines = DEFAULT_PIPELINES + tuple(addon_pipelines)
+
+        add_package_to_scan_queue(self, pipelines=pipelines, reindex_uri=True, priority=100)
 
     def update_fields(self, save=False, **values_by_fields):
         """

--- a/packagedb/serializers.py
+++ b/packagedb/serializers.py
@@ -379,6 +379,7 @@ class CollectPackageSerializer(Serializer):
         )
 
     addon_pipelines = ListField(
+        child = CharField(),
         required=False,
         allow_empty=True,
         help_text="Addon pipelines to run on the package.",
@@ -398,6 +399,14 @@ class CollectPackageSerializer(Serializer):
             except ValueError as e:
                 raise ValidationError(f'purl validation error: {e}')
         return value
+
+    def validate_addon_pipelines(self, value):
+        invalid_pipelines = [pipe for pipe in value if not is_supported_addon_pipeline(pipe)]
+        if invalid_pipelines:
+            raise ValidationError(f'Error unsupported addon pipelines: {",".join(invalid_pipelines)}')
+
+        return value
+
 
 class PackageVersSerializer(Serializer):
     purl = CharField()
@@ -486,3 +495,8 @@ class PurltoGitRepoSerializer(Serializer):
 
 class PurltoGitRepoResponseSerializer(Serializer):
     git_repo = CharField(required=True)
+
+
+def is_supported_addon_pipeline(addon_pipeline):
+    from minecode.model_utils import SUPPORTED_ADDON_PIPELINES
+    return addon_pipeline in SUPPORTED_ADDON_PIPELINES


### PR DESCRIPTION
- `/api/collect` endpoint now supports optional list of `addon_pipelines` to run on the package.
  Example GET request:
  ```url
    /api/collect/?purl=pkg:npm/foo@1.2.3&addon_pipelines=collect_symbols&addon_pipelines=inspect_elf_binaries
   ```
- In bulk indexing `/api/collect/index_packages/` endpoint each package now also supports optional list of `addon_pipelines` to run on the package.
  Example POST request:
  ```url
    {
        "packages": [
            {
                "purl": "pkg:npm/foobar",
                "vers": null,
                "source_purl": None,
                "addon_pipelines": ['inspect_elf_binaries', 'collect_symbols']
            }
        ]
        "reindex": true,
        "reindex_set": false,
    }
   ```

- fixes https://github.com/nexB/purldb/issues/376

</br>

> [!note]
> If no addon_pipeline is provided, then only the default pipelines  will be run on the package.
> https://github.com/nexB/purldb/blob/32ea6e810c3c371e24318440f079a7453f1c5d4a/minecode/model_utils.py#L30-L33