### PR TITLE
Add purld2vcs as a purldb dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ install_requires =
     scancode-toolkit[packages] @ git+https://github.com/nexB/scancode-toolkit.git@684360f2ca01bc676368bc8621eed65065bf0f11
     urlpy == 0.5
     matchcode-toolkit == 5.1.0
+    purl2vcs == 1.0.1
     univers == 30.11.0
     scancodeio @ git+https://github.com/nexB/scancode.io.git@07b48c0224f5c2ad1b2972b693702ef685f16c98
 setup_requires = setuptools_scm[toml] >= 4


### PR DESCRIPTION
This was failing deployment otherwise:
```
purldb-web-1  |   File "/app/purldb_project/urls.py", line 18, in <module>
purldb-web-1  |     from packagedb.api import PackageViewSet
purldb-web-1  |   File "/app/packagedb/api.py", line 72, in <module>
purldb-web-1  |     from purl2vcs.find_source_repo import get_source_package_and_add_to_package_set
purldb-web-1  | ModuleNotFoundError: No module named 'purl2vcs.find_source_repo'
```