### PR TITLE
502 queue priority update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@ Next Release
   ``approximate_directory_structure_index``, ``exact_file_index``,
   ``exact_package_archive_index``, ``cditems``, ``on_demand_queue`` have been
   removed.
+- The `/api/collect/` and `/api/collect/index_packages/` API endpoints have been
+  updated such that Package scan and processing requests made with purls with
+  versions are processed ahead of those made with versionless purls. https://github.com/nexB/purldb/issues/502
 
 
 v5.0.0

--- a/docs/source/purldb/rest_api.rst
+++ b/docs/source/purldb/rest_api.rst
@@ -875,7 +875,7 @@ index_packages
 
 Take a list of ``packages`` (where each item is a dictionary containing either PURL
 or versionless PURL along with vers range, optionally with source package PURL)
-and index it.
+and index it. PURLs with versions are processed ahead of versionless PURLs.
 Also each package can have list of ``addon_pipelines`` to run on the package.
 Find all addon pipelines `here. <https://scancodeio.readthedocs.io/en/latest/built-in-pipelines.html>`_
 

--- a/minecode/management/commands/priority_queue.py
+++ b/minecode/management/commands/priority_queue.py
@@ -109,15 +109,18 @@ def process_request(priority_resource_uri, _priority_router=priority_router):
     purl_to_visit = priority_resource_uri.uri
     source_purl = priority_resource_uri.source_uri
     addon_pipelines = priority_resource_uri.addon_pipelines
+    priority = priority_resource_uri.priority
 
     try:
         if TRACE:
             logger.debug('visit_uri: uri: {}'.format(purl_to_visit))
         kwargs = dict()
         if source_purl:
-            kwargs["source_purl"] = source_purl
+            kwargs['source_purl'] = source_purl
         if addon_pipelines:
-            kwargs["addon_pipelines"] = addon_pipelines
+            kwargs['addon_pipelines'] = addon_pipelines
+        if priority:
+            kwargs['priority'] = priority
         errors = _priority_router.process(purl_to_visit, **kwargs)
         if TRACE:
             new_uris_to_visit = list(new_uris_to_visit or [])

--- a/minecode/model_utils.py
+++ b/minecode/model_utils.py
@@ -46,7 +46,9 @@ SUPPORTED_ADDON_PIPELINES = (
 
 def add_package_to_scan_queue(package, pipelines=DEFAULT_PIPELINES, priority=0, reindex_uri=False):
     """
-    Add a Package `package` to the scan queue to run the list of provided `pipelines`
+    Add a Package `package` to the scan queue to run the list of provided
+    `pipelines` with a given `priority`. A ScannableURI with a `priority` of 100
+    will be processed before a ScannableURI with a `priority` of 0.
 
     If `reindex_uri` is True, force rescanning of the package
     """

--- a/minecode/model_utils.py
+++ b/minecode/model_utils.py
@@ -44,7 +44,7 @@ SUPPORTED_ADDON_PIPELINES = (
 )
 
 
-def add_package_to_scan_queue(package, pipelines=DEFAULT_PIPELINES, reindex_uri=False, priority=100):
+def add_package_to_scan_queue(package, pipelines=DEFAULT_PIPELINES, priority=0, reindex_uri=False):
     """
     Add a Package `package` to the scan queue to run the list of provided `pipelines`
 
@@ -226,7 +226,7 @@ def merge_or_create_package(scanned_package, visit_level, override=False):
 
     If ``scanned_package`` does not exist in the PackageDB, create a new entry in
     the PackageDB for ``scanned_package``.
-    
+
     If ``override`` is True, then all existing empty values of the PackageDB package are replaced by
     a non-empty value of the provided override.
     """

--- a/minecode/visitors/conan.py
+++ b/minecode/visitors/conan.py
@@ -99,7 +99,7 @@ def get_download_info(conandata, version):
     return download_url, sha256
 
 
-def map_conan_package(package_url, pipelines):
+def map_conan_package(package_url, pipelines, priority=0):
     """
     Add a conan `package_url` to the PackageDB.
 
@@ -134,7 +134,7 @@ def map_conan_package(package_url, pipelines):
 
     # Submit package for scanning
     if db_package:
-        add_package_to_scan_queue(db_package, pipelines)
+        add_package_to_scan_queue(db_package, pipelines, priority)
 
     return error
 
@@ -154,11 +154,12 @@ def process_request(purl_str, **kwargs):
     package_url = PackageURL.from_string(purl_str)
     addon_pipelines = kwargs.get('addon_pipelines', [])
     pipelines = DEFAULT_PIPELINES + tuple(addon_pipelines)
+    priority = kwargs.get('priority', 0)
 
     if not package_url.version:
         return
 
-    error_msg = map_conan_package(package_url, pipelines)
+    error_msg = map_conan_package(package_url, pipelines, priority)
 
     if error_msg:
         return error_msg

--- a/minecode/visitors/generic.py
+++ b/minecode/visitors/generic.py
@@ -27,7 +27,7 @@ logger.addHandler(handler)
 logger.setLevel(logging.INFO)
 
 
-def map_generic_package(package_url, pipelines):
+def map_generic_package(package_url, pipelines, priority=0):
     """
     Add a generic `package_url` to the PackageDB.
 
@@ -52,7 +52,11 @@ def map_generic_package(package_url, pipelines):
 
     # Submit package for scanning
     if db_package:
-        add_package_to_scan_queue(db_package, pipelines)
+        add_package_to_scan_queue(
+            package=db_package,
+            pipelines=pipelines,
+            priority=priority,
+        )
 
     return error
 
@@ -67,6 +71,7 @@ def process_request(purl_str, **kwargs):
 
     addon_pipelines = kwargs.get('addon_pipelines', [])
     pipelines = DEFAULT_PIPELINES + tuple(addon_pipelines)
+    priority = kwargs.get('priority', 0)
 
     try:
         package_url = PackageURL.from_string(purl_str)
@@ -79,7 +84,7 @@ def process_request(purl_str, **kwargs):
         error = f'package_url {purl_str} does not contain a download_url qualifier'
         return error
 
-    error_msg = map_generic_package(package_url, pipelines)
+    error_msg = map_generic_package(package_url, pipelines, priority)
 
     if error_msg:
         return error_msg
@@ -97,7 +102,7 @@ def packagedata_from_dict(package_data):
     return PackageData.from_data(cleaned_package_data)
 
 
-def map_fetchcode_supported_package(package_url, pipelines):
+def map_fetchcode_supported_package(package_url, pipelines, priority=0):
     """
     Add a `package_url` supported by fetchcode to the PackageDB.
 
@@ -122,7 +127,11 @@ def map_fetchcode_supported_package(package_url, pipelines):
 
     # Submit package for scanning
     if db_package:
-        add_package_to_scan_queue(db_package, pipelines)
+        add_package_to_scan_queue(
+            package=db_package,
+            pipelines=pipelines,
+            priority=priority,
+        )
 
     return error
 
@@ -176,6 +185,7 @@ def process_request_fetchcode_generic(purl_str, **kwargs):
 
     addon_pipelines = kwargs.get('addon_pipelines', [])
     pipelines = DEFAULT_PIPELINES + tuple(addon_pipelines)
+    priority = kwargs.get('priority', 0)
 
     try:
         package_url = PackageURL.from_string(purl_str)
@@ -183,7 +193,7 @@ def process_request_fetchcode_generic(purl_str, **kwargs):
         error = f"error occurred when parsing {purl_str}: {e}"
         return error
 
-    error_msg = map_fetchcode_supported_package(package_url, pipelines)
+    error_msg = map_fetchcode_supported_package(package_url, pipelines, priority)
 
     if error_msg:
         return error_msg

--- a/minecode/visitors/github.py
+++ b/minecode/visitors/github.py
@@ -198,13 +198,15 @@ def process_request_dir_listed(purl_str, **kwargs):
 
     addon_pipelines = kwargs.get('addon_pipelines', [])
     pipelines = DEFAULT_PIPELINES + tuple(addon_pipelines)
+    priority = kwargs.get('priority', 0)
+
     try:
         package_url = PackageURL.from_string(purl_str)
     except ValueError as e:
         error = f"error occurred when parsing {purl_str}: {e}"
         return error
 
-    error_msg = map_fetchcode_supported_package(package_url, pipelines)
+    error_msg = map_fetchcode_supported_package(package_url, pipelines, priority)
 
     if error_msg:
         return error_msg

--- a/minecode/visitors/gnu.py
+++ b/minecode/visitors/gnu.py
@@ -35,12 +35,13 @@ def process_request(purl_str, **kwargs):
 
     addon_pipelines = kwargs.get('addon_pipelines', [])
     pipelines = DEFAULT_PIPELINES + tuple(addon_pipelines)
+    priority = kwargs.get('priority', 0)
 
     package_url = PackageURL.from_string(purl_str)
     if not package_url.version:
         return
 
-    error_msg = map_fetchcode_supported_package(package_url, pipelines)
+    error_msg = map_fetchcode_supported_package(package_url, pipelines, priority)
 
     if error_msg:
         return error_msg

--- a/minecode/visitors/npm.py
+++ b/minecode/visitors/npm.py
@@ -127,7 +127,7 @@ def get_package_json(namespace, name, version):
         logger.error(f"HTTP error occurred: {err}")
 
 
-def map_npm_package(package_url, pipelines):
+def map_npm_package(package_url, pipelines, priority=0):
     """
     Add a npm `package_url` to the PackageDB.
 
@@ -156,7 +156,11 @@ def map_npm_package(package_url, pipelines):
 
     # Submit package for scanning
     if db_package:
-        add_package_to_scan_queue(db_package, pipelines)
+        add_package_to_scan_queue(
+            package=db_package,
+            pipelines=pipelines,
+            priority=priority
+        )
 
     return error
 
@@ -172,15 +176,16 @@ def process_request(purl_str, **kwargs):
     scan queue afterwards.
     """
     from minecode.model_utils import DEFAULT_PIPELINES
-    
+
     addon_pipelines = kwargs.get('addon_pipelines', [])
     pipelines = DEFAULT_PIPELINES + tuple(addon_pipelines)
+    priority = kwargs.get('priority', 0)
 
     package_url = PackageURL.from_string(purl_str)
     if not package_url.version:
         return
 
-    error_msg = map_npm_package(package_url, pipelines)
+    error_msg = map_npm_package(package_url, pipelines, priority)
 
     if error_msg:
         return error_msg

--- a/minecode/visitors/openssl.py
+++ b/minecode/visitors/openssl.py
@@ -91,6 +91,7 @@ class OpenSSLVisitor(HttpVisitor):
             else:
                 yield URI(uri=url, source_uri=self.uri, date=date, size=size)
 
+
 # Indexing OpenSSL PURLs requires a GitHub API token.
 # Please add your GitHub API key to the `.env` file, for example: `GH_TOKEN=your-github-api`.
 @priority_router.route('pkg:openssl/openssl@.*')
@@ -104,9 +105,10 @@ def process_request_dir_listed(purl_str, **kwargs):
     PackageDB entry. The package is then added to the scan queue afterwards.
     """
     from minecode.model_utils import DEFAULT_PIPELINES
-    
+
     addon_pipelines = kwargs.get('addon_pipelines', [])
     pipelines = DEFAULT_PIPELINES + tuple(addon_pipelines)
+    priority = kwargs.get('priority', 0)
 
     try:
         package_url = PackageURL.from_string(purl_str)
@@ -114,7 +116,7 @@ def process_request_dir_listed(purl_str, **kwargs):
         error = f"error occurred when parsing {purl_str}: {e}"
         return error
 
-    error_msg = map_fetchcode_supported_package(package_url, pipelines)
+    error_msg = map_fetchcode_supported_package(package_url, pipelines, priority)
 
     if error_msg:
         return error_msg

--- a/packagedb/api.py
+++ b/packagedb/api.py
@@ -1009,9 +1009,11 @@ class CollectViewSet(viewsets.ViewSet):
                     # add to queue
                     extra_fields = dict()
                     if source_purl := package.get('source_purl'):
-                        extra_fields["source_uri"] = source_purl
+                        extra_fields['source_uri'] = source_purl
                     if addon_pipelines := package.get('addon_pipelines'):
-                        extra_fields["addon_pipelines"] = [pipe for pipe in addon_pipelines if is_supported_addon_pipeline(pipe)]
+                        extra_fields['addon_pipelines'] = [pipe for pipe in addon_pipelines if is_supported_addon_pipeline(pipe)]
+                    if priority := package.get('priority'):
+                        extra_fields['priority'] = priority
                     priority_resource_uri = PriorityResourceURI.objects.insert(purl, **extra_fields)
                     if priority_resource_uri:
                         queued_packages.append(purl)
@@ -1238,6 +1240,8 @@ def get_resolved_packages(packages, supported_ecosystems):
             continue
 
         if parsed_purl.version:
+            # We prioritize Package requests that have explicit versions
+            package['priority'] = 100
             resolved_packages_by_purl[purl] = package
             continue
 

--- a/packagedb/api.py
+++ b/packagedb/api.py
@@ -783,7 +783,7 @@ class CollectViewSet(viewsets.ViewSet):
       like with several Debian packages.
 
     **Examples::**
-    
+
         /api/collect/?purl=pkg:npm/foo@0.0.7&addon_pipelines=collect_symbols_ctags
 
         /api/collect/?purl=pkg:generic/busybox@1.36.1&addon_pipelines=collect_symbols_ctags&addon_pipelines=inspect_elf_binaries
@@ -818,6 +818,10 @@ class CollectViewSet(viewsets.ViewSet):
         purl = validated_data.get('purl')
 
         kwargs = dict()
+        # We want this request to have high priority since the user knows the
+        # exact package they want
+        kwargs['priority'] = 100
+
         if source_purl := validated_data.get('source_purl', None):
             kwargs["source_purl"] = source_purl
 
@@ -1048,9 +1052,9 @@ class CollectViewSet(viewsets.ViewSet):
         If the package does not exist in the database this call does nothing.
         NOTE: this WILL NOT re-run scan and indexing in the background in contrast with the /collect
         and collect/index_packages endpoints.
-        
+
         **Request example**::
-        
+
             /api/collect/reindex_metadata/?purl=pkg:npm/foo@0.0.7
 
         """
@@ -1068,10 +1072,10 @@ class CollectViewSet(viewsets.ViewSet):
         packages = Package.objects.filter(**lookups)
         if packages.count() == 0:
             return Response(
-                {'status': f'Not recollecting: Package does not exist for {purl}'}, 
+                {'status': f'Not recollecting: Package does not exist for {purl}'},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        
+
         # Pass to only reindex_metadata downstream
         kwargs["reindex_metadata"] = True
         # here we have a package(s) matching our purl and we want to recollect metadata live

--- a/packagedb/tests/test_api.py
+++ b/packagedb/tests/test_api.py
@@ -813,6 +813,14 @@ class CollectApiTestCase(JsonBasedTesting, TestCase):
 
         self.check_expected_results(result, expected, fields_to_remove=fields_to_remove, regen=FIXTURES_REGEN)
 
+        # Ensure that the created ScannableURI objects have a priority of 100
+        package = Package.objects.get(download_url=download_url)
+        source_package = Package.objects.get(download_url=sources_download_url)
+        package_scannable_uri = ScannableURI.objects.get(package=package)
+        source_package_scannable_uri = ScannableURI.objects.get(package=source_package)
+        self.assertEqual(100, package_scannable_uri.priority)
+        self.assertEqual(100, source_package_scannable_uri.priority)
+
     def test_package_live_works_with_purl2vcs(self):
         purl = "pkg:maven/org.elasticsearch.plugin/elasticsearch-scripting-painless-spi@6.8.15"
         download_url = 'https://repo1.maven.org/maven2/org/elasticsearch/plugin/elasticsearch-scripting-painless-spi/6.8.15/elasticsearch-scripting-painless-spi-6.8.15.jar'


### PR DESCRIPTION
This PR updates the `/api/collect` and `/api/collect/index_packages/` endpoints where purls with versions are placed in the front of the scan queue. This is done as it is assumed that if the user knows which versions of a package they want to look at, they would probably want to see it sooner.