### PR TITLE
Update collect API status codes

### DIFF
--- a/minecode/tests/test_maven.py
+++ b/minecode/tests/test_maven.py
@@ -711,6 +711,13 @@ class MavenPriorityQueueTests(JsonBasedTesting, DjangoTestCase):
                 f.write(pom_contents)
         self.assertEqual(self.expected_pom_contents, pom_contents)
 
+        pom_contents = maven_visitor.get_pom_text(
+            namespace='',
+            name='does-not-exist',
+            version='1.0',
+        )
+        self.assertFalse(pom_contents)
+
     def test_get_package_sha1(self):
         sha1 = maven_visitor.get_package_sha1(self.scan_package)
         expected_sha1 = '60c708f55deeb7c5dfce8a7886ef09cbc1388eca'

--- a/minecode/visitors/maven.py
+++ b/minecode/visitors/maven.py
@@ -125,6 +125,8 @@ def get_pom_text(namespace, name, version, qualifiers={}, base_url=MAVEN_BASE_UR
         qualifiers=qualifiers,
         base_url=base_url,
     )
+    if not urls:
+        return
     # Get and parse POM info
     pom_url = urls['api_data_url']
     # TODO: manage different types of errors (404, etc.)

--- a/packagedb/api.py
+++ b/packagedb/api.py
@@ -250,13 +250,13 @@ class ResourceViewSet(viewsets.ReadOnlyModelViewSet):
             response_data = {
                 'status': f'Unsupported field(s) given: {unsupported_fields_str}'
             }
-            return Response(response_data)
+            return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
 
         if not data:
             response_data = {
                 'status': 'No values provided'
             }
-            return Response(response_data)
+            return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
 
         lookups = Q()
         for field, value in data.items():
@@ -467,14 +467,14 @@ class PackagePublicViewSet(viewsets.ReadOnlyModelViewSet):
             response_data = {
                 'status': f'Unsupported field(s) given: {unsupported_fields_str}'
             }
-            return Response(response_data)
+            return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
 
         enhance_package_data = data.pop('enhance_package_data', False)
         if not data:
             response_data = {
                 'status': 'No values provided'
             }
-            return Response(response_data)
+            return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
 
         lookups = Q()
         for field, value in data.items():
@@ -546,7 +546,7 @@ class PackageUpdateSet(viewsets.ViewSet):
         serializer = UpdatePackagesSerializer(data=request.data)
 
         if not serializer.is_valid():
-            return Response({'errors': serializer.errors}, status=400)
+            return Response({'errors': serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
 
         validated_data = serializer.validated_data
         packages = validated_data.get('purls', [])
@@ -812,7 +812,7 @@ class CollectViewSet(viewsets.ViewSet):
             return Response(
                 {'errors': serializer.errors},
                 status=status.HTTP_400_BAD_REQUEST,
-                )
+            )
 
         validated_data = serializer.validated_data
         purl = validated_data.get('purl')
@@ -847,7 +847,7 @@ class CollectViewSet(viewsets.ViewSet):
                     message = {
                         'status': f'error(s) occurred when fetching metadata for {purl}: {errors}'
                     }
-                return Response(message)
+                return Response(message, status=status.HTTP_400_BAD_REQUEST)
         for package in packages:
             get_source_package_and_add_to_package_set(package)
 
@@ -960,7 +960,7 @@ class CollectViewSet(viewsets.ViewSet):
         serializer = self.serializer_class(data=request.data)
 
         if not serializer.is_valid():
-            return Response({'errors': serializer.errors}, status=400)
+            return Response({'errors': serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
 
         validated_data = serializer.validated_data
         packages = validated_data.get('packages', [])
@@ -1065,7 +1065,7 @@ class CollectViewSet(viewsets.ViewSet):
             return Response(
                 {'errors': serializer.errors},
                 status=status.HTTP_400_BAD_REQUEST,
-                )
+            )
 
         validated_data = serializer.validated_data
         purl = validated_data.get('purl')
@@ -1097,7 +1097,7 @@ class CollectViewSet(viewsets.ViewSet):
                 message = {
                     'status': f'error(s) occurred when fetching metadata for {purl}: {errors}'
                 }
-            return Response(message)
+            return Response(message, status=status.HTTP_400_BAD_REQUEST)
 
         serializer = PackageAPISerializer(packages, many=True, context={'request': request})
         return Response(serializer.data)
@@ -1169,7 +1169,7 @@ class PurlValidateViewSet(viewsets.ViewSet):
             package_url = PackageURL.from_string(purl)
         except ValueError:
             serializer = PurlValidateResponseSerializer(response, context={'request': request})
-            return Response(serializer.data)
+            return Response(serializer.data, status=status.HTTP_400_BAD_REQUEST)
 
         response['valid'] = True
         response["message"] = message_valid


### PR DESCRIPTION
This PR updates the code in the collect API, where we now return the proper http status code for error responses.