### PR TITLE
Add config options for Redis connection (TLS, username, DB)

### DIFF
--- a/purldb_project/settings.py
+++ b/purldb_project/settings.py
@@ -309,8 +309,14 @@ RQ_QUEUES = {
     "default": {
         "HOST": env.str("PURLDB_REDIS_HOST", default="localhost"),
         "PORT": env.str("PURLDB_REDIS_PORT", default="6379"),
+        "DB": env.int("PURLDB_REDIS_DB", default=0),
+        "USERNAME": env.str("PURLDB_REDIS_USERNAME", default=None),
         "PASSWORD": env.str("PURLDB_REDIS_PASSWORD", default=""),
         "DEFAULT_TIMEOUT": env.int("PURLDB_REDIS_DEFAULT_TIMEOUT", default=360),
+        # Enable SSL for Redis connections when deploying purldb in environments
+        # where Redis is hosted on a separate system (e.g., cloud deployment or
+        # remote Redis server) to secure data in transit.
+        "SSL": env.bool("PURLDB_REDIS_SSL", default=False)
     }
 }
 


### PR DESCRIPTION
This modification allows to establish a secure connection to an external Redis instance in scenarios where PurlDB is not deployed via docker compose. The current defaults are kept for compatibility reasons. This means by default no TLS is used, as is currently already the case, as a local deployment with docker compose is assumed where all services are runing on the same host. Similar fixes have been made in DejaCode (https://github.com/aboutcode-org/dejacode/commit/1a4f7039d823fdddc05e22f0f61406f1f22f9077) and ScanCode.io (https://github.com/aboutcode-org/scancode.io/commit/f0750d4a9f93bd645dac9fa9ebe3dc0e0871f5bc).