### PR TITLE
Fix #613: avoid selecting unrelated repositories as source repo

### DIFF
--- a/purl2vcs/src/purl2vcs/find_source_repo.py
+++ b/purl2vcs/src/purl2vcs/find_source_repo.py
@@ -196,14 +196,11 @@ def get_source_repo(package: Package) -> PackageURL:
     repo_urls = list(get_repo_urls(package))
     if not repo_urls:
         return
-
     # dedupe repo urls
     repo_urls = list(set(repo_urls))
-
     source_purls = list(convert_repo_urls_to_purls(repo_urls))
     if not source_purls:
         return
-
     # Filter out clearly unrelated repositories
     pkg_name = package.name.lower()
     filtered_source_purls = []
@@ -217,11 +214,9 @@ def get_source_repo(package: Package) -> PackageURL:
         source_purls = filtered_source_purls
 
     source_purls = list(set(source_purls))
-
     source_purl_with_tag = find_package_version_tag_and_commit(
         version=package.version, source_purls=source_purls
     )
-
     if source_purl_with_tag:
         return source_purl_with_tag
 

--- a/purl2vcs/src/purl2vcs/find_source_repo.py
+++ b/purl2vcs/src/purl2vcs/find_source_repo.py
@@ -196,18 +196,34 @@ def get_source_repo(package: Package) -> PackageURL:
     repo_urls = list(get_repo_urls(package))
     if not repo_urls:
         return
+
     # dedupe repo urls
     repo_urls = list(set(repo_urls))
+
     source_purls = list(convert_repo_urls_to_purls(repo_urls))
     if not source_purls:
         return
+
+    # Filter out clearly unrelated repositories
+    pkg_name = package.name.lower()
+    filtered_source_purls = []
+
+    for purl in source_purls:
+        repo_name = (purl.name or "").lower()
+        if repo_name in pkg_name or pkg_name in repo_name:
+            filtered_source_purls.append(purl)
+
+    if filtered_source_purls:
+        source_purls = filtered_source_purls
+
     source_purls = list(set(source_purls))
+
     source_purl_with_tag = find_package_version_tag_and_commit(
         version=package.version, source_purls=source_purls
     )
+
     if source_purl_with_tag:
         return source_purl_with_tag
-
 
 def get_repo_urls(package: Package) -> Generator[str, None, None]:
     """

--- a/purl2vcs/tests/test_find_source_repo.py
+++ b/purl2vcs/tests/test_find_source_repo.py
@@ -311,3 +311,25 @@ class TestFindSourceRepo(TestCase):
         )
         expected = "pkg:bitbucket/connect2id/oauth-2.0-sdk-with-openid-connect-extensions@9.36?commit=e86fb3431972d302fcb615aca0baed4d8ab89791"
         self.assertEqual(expected, response.data["git_repo"])
+
+    def test_filter_unrelated_repo_candidates(self):
+        """
+        Ensure unrelated repository candidates are filtered when
+        detecting the source repository.
+        """
+
+        pkg_name = "inherits"
+
+        source_purls = [
+            PackageURL(type="github", namespace="substack", name="node-browserify"),
+            PackageURL(type="github", namespace="isaacs", name="inherits"),
+        ]
+
+        filtered = []
+        for purl in source_purls:
+            repo_name = (purl.name or "").lower()
+            if repo_name in pkg_name or pkg_name in repo_name:
+                filtered.append(purl)
+
+        self.assertTrue(any(p.name == "inherits" for p in filtered))
+        self.assertFalse(any(p.name == "node-browserify" for p in filtered))


### PR DESCRIPTION
Fixes #613

## Problem
When running the collect endpoint for `npm` package `inherits@2.0.0`, purldb incorrectly detected `pkg:github/substack/node-browserify` as the source repository.

This happens because repository URLs extracted from metadata, homepages, or descriptions may include unrelated GitHub links, which are then treated as valid source repositories.

## Solution
Add a filter in `get_source_repo()` to prefer repository candidates whose repository name overlaps with the package name. If at least one such candidate exists, unrelated repositories are ignored. If none match, the original behavior is preserved.
