### PR TITLE
Fix NameError when visit_error is set in visit_uri (#851)

### DIFF
--- a/minecode/management/commands/run_visit.py
+++ b/minecode/management/commands/run_visit.py
@@ -278,8 +278,8 @@ def visit_uri(resource_uri, max_uris=0, uri_counter_by_visitor=None, _visit_rout
     except (ConnectionError, Timeout, Exception) as e:
         # FIXME: is catching all exceptions here correct?
         msg = f"Visit error for URI: {uri_to_visit}"
-        msg += "\n".format()
-        msg += get_error_message(e)
+        msg += "\n"
+        msg += str(visit_error)
         visit_errors.append(msg)
         logger.error(msg)
 
@@ -287,8 +287,8 @@ def visit_uri(resource_uri, max_uris=0, uri_counter_by_visitor=None, _visit_rout
     # Also log visit errors!!!1
     if visit_error:
         msg = f"Visit error for URI: {uri_to_visit}"
-        msg += "\n".format()
-        msg += get_error_message(e)  # NOQA
+        msg += "\n"
+        msg += str(visit_error)
         visit_errors.append(msg)
         logger.error(msg)
 

--- a/minecode/management/commands/run_visit.py
+++ b/minecode/management/commands/run_visit.py
@@ -279,7 +279,7 @@ def visit_uri(resource_uri, max_uris=0, uri_counter_by_visitor=None, _visit_rout
         # FIXME: is catching all exceptions here correct?
         msg = f"Visit error for URI: {uri_to_visit}"
         msg += "\n"
-        msg += str(visit_error)
+        msg += get_error_message(e)
         visit_errors.append(msg)
         logger.error(msg)
 


### PR DESCRIPTION
**Description**

This PR fixes a potential `NameError` in `visit_uri()` located in `minecode/management/commands/run_visit.py`.

Previously, the code referenced the exception variable `e` inside the `if visit_error:` block:

```
msg += get_error_message(e)
```

However, `e` is only defined inside the `except` block:

```
except (ConnectionError, Timeout, Exception) as e:
```

If `_visit_router.process(uri_to_visit)` returns a `visit_error` without raising an exception, the `if visit_error:` block executes while `e` is undefined, causing:

```
NameError: name 'e' is not defined
```

This PR resolves the issue by removing the reference to `e` and using `visit_error` directly when logging the error message.

This ensures the error logging works correctly even when no exception was raised.

Fixes #851.
