### PR TITLE
Fix: Preserve version ordering in VersionResponse

### DIFF
--- a/packagedb/package_managers.py
+++ b/packagedb/package_managers.py
@@ -45,8 +45,8 @@ class PackageVersion:
 
 @dataclasses.dataclass
 class VersionResponse:
-    valid_versions: set[str] = dataclasses.field(default_factory=set)
-    newer_versions: set[str] = dataclasses.field(default_factory=set)
+    valid_versions: list[str] = dataclasses.field(default_factory=list)
+    newer_versions: list[str] = dataclasses.field(default_factory=list)
 
 
 def get_response(url, content_type="json", headers=None):
@@ -112,14 +112,19 @@ class VersionAPI:
         optional ``until`` datetime object for a date "until" which to fetch
         versions.
         """
-        new_versions = set()
-        valid_versions = set()
+        new_versions = []
+        valid_versions = []
+        seen_new_versions = set()
+        seen_valid_versions = set()
 
         for version in self.fetch(package_name):
             if until and version.release_date and version.release_date > until:
-                new_versions.add(version.value)
-            else:
-                valid_versions.add(version.value)
+                if version.value not in seen_new_versions:
+                    new_versions.append(version.value)
+                    seen_new_versions.add(version.value)
+            elif version.value not in seen_valid_versions:
+                valid_versions.append(version.value)
+                seen_valid_versions.add(version.value)
 
         return VersionResponse(valid_versions=valid_versions, newer_versions=new_versions)
 

--- a/packagedb/tests/test_package_managers.py
+++ b/packagedb/tests/test_package_managers.py
@@ -246,7 +246,22 @@ class TestMavenVersionAPI(TestCase):
             mock_response.return_value = f.read()
 
         assert MavenVersionAPI().get_until("org.apache:kafka") == VersionResponse(
-            valid_versions={"1.3.0", "1.2.2", "1.2.3"}, newer_versions=set()
+            valid_versions=["1.3.0", "1.2.2", "1.2.3q"], newer_versions=[]
+        )
+
+    def test_get_until_preserves_fetch_order_and_deduplicates(self):
+        class DummyVersionAPI(MavenVersionAPI):
+            def fetch(self, package_name):
+                yield PackageVersion("1.0.0", release_date=dt_local(2024, 1, 1, 0, 0, 0))
+                yield PackageVersion("1.0.0", release_date=dt_local(2024, 1, 1, 0, 0, 0))
+                yield PackageVersion("1.1.0", release_date=dt_local(2024, 2, 1, 0, 0, 0))
+                yield PackageVersion("0.9.0", release_date=dt_local(2023, 12, 1, 0, 0, 0))
+
+        until = dt_local(2024, 1, 15, 0, 0, 0)
+
+        assert DummyVersionAPI().get_until("unused", until=until) == VersionResponse(
+            valid_versions=["1.0.0", "0.9.0"],
+            newer_versions=["1.1.0"],
         )
 
     @mock.patch("packagedb.package_managers.get_response")


### PR DESCRIPTION
Closes #857 

## What this changes

This updates `packagedb.package_managers.VersionAPI.get_until()` to preserve the original version order returned by `fetch()`.

Previously, `VersionResponse.valid_versions` and `newer_versions` were built using sets. That removed duplicates, but it also lost the original ordering of versions.

This change switches the returned values to ordered lists and keeps deduplication with internal `seen` sets.

## Why

There is already a related note in `packagedb/package_managers.py`:

`# FIXME: DO NOT use set() for storing version lists: they lose the original ordering`

Preserving version order makes the behavior more predictable while still avoiding duplicate version values.

## Tests

Updated `packagedb/tests/test_package_managers.py` to:
- expect ordered results from `get_until()`
- add a regression test that checks both order preservation and deduplication
