### PR TITLE
Fix: Add doctest and tests for clearcode coordinate helpers

### DIFF
--- a/clearcode/cdutils.py
+++ b/clearcode/cdutils.py
@@ -524,8 +524,14 @@ def str2coord(s):
         URL: "cd:/gem/rubygems/-/mocha/1.7.0"
         URN: "urn:gem:rubygems:-:mocha:revision:1.7.0:tool:scancode:3.1.0"
         plain: /gem/rubygems/foo/mocha/1.7.0"
+
+    >>> str2coord("cd:/gem/rubygems/-/mocha/1.7.0")
+    {'type': 'gem', 'provider': 'rubygems', 'namespace': '-', 'name': 'mocha', 'revision': '1.7.0'}
+    >>> str2coord("urn:gem:rubygems:-:mocha:revision:1.7.0:tool:scancode:3.1.0")
+    {'type': 'gem', 'provider': 'rubygems', 'namespace': '-', 'name': 'mocha', 'revision': '1.7.0'}
+    >>> str2coord("/gem/rubygems/foo/mocha/1.7.0")
+    {'type': 'gem', 'provider': 'rubygems', 'namespace': 'foo', 'name': 'mocha', 'revision': '1.7.0'}
     """
-    # TODO: Add doctest
     is_urn = s.startswith("urn")
     is_url = s.startswith("cd:")
     splitter = ":" if is_urn else "/"

--- a/clearcode/tests/test_sync.py
+++ b/clearcode/tests/test_sync.py
@@ -21,6 +21,8 @@ import json
 
 from django.test import TestCase
 
+from clearcode.cdutils import coord2str
+from clearcode.cdutils import str2coord
 from clearcode.models import CDitem
 from clearcode.sync import db_saver
 
@@ -42,3 +44,34 @@ class SyncDbsaverTestCase(TestCase):
     def test_db_saver_different_path(self):
         db_saver(content=self.test_content, blob_path="new/blob/path.json")
         self.assertEqual(2, len(CDitem.objects.all()))
+
+
+class CDUtilsTestCase(TestCase):
+    def test_str2coord_from_cd_url(self):
+        assert str2coord("cd:/gem/rubygems/-/mocha/1.7.0") == {
+            "type": "gem",
+            "provider": "rubygems",
+            "namespace": "-",
+            "name": "mocha",
+            "revision": "1.7.0",
+        }
+
+    def test_str2coord_from_urn_ignores_extra_segments(self):
+        assert str2coord("urn:gem:rubygems:-:mocha:revision:1.7.0:tool:scancode:3.1.0") == {
+            "type": "gem",
+            "provider": "rubygems",
+            "namespace": "-",
+            "name": "mocha",
+            "revision": "1.7.0",
+        }
+
+    def test_coord2str_preserves_missing_namespace_as_dash(self):
+        assert coord2str(
+            {
+                "type": "git",
+                "provider": "github",
+                "namespace": None,
+                "name": "license-expression",
+                "revision": "70277cdfc186466667cb58ec9f9c7281e68a221b",
+            }
+        ) == "git/github/-/license-expression/70277cdfc186466667cb58ec9f9c7281e68a221b"


### PR DESCRIPTION
Closes #861 

This adds the missing doctest requested in `clearcode.cdutils.str2coord()` and adds focused tests for `str2coord()` and `coord2str()`.

The new coverage verifies:
- parsing coordinates from a ClearlyDefined URL
- parsing coordinates from a URN while ignoring extra trailing segments
- preserving `-` for a missing namespace when converting coordinates back to string form
