### PR TITLE
Fix PyPI latest-date handling when upload_time_iso_8601 is missing

### DIFF
--- a/packagedb/package_managers.py
+++ b/packagedb/package_managers.py
@@ -218,13 +218,12 @@ class PypiVersionAPI(VersionAPI):
         latest_date = None
         for download in downloads:
             upload_time = download.get("upload_time_iso_8601")
-            if upload_time:
-                current_date = dateparser.parse(upload_time)
-            if not latest_date:
+            if not upload_time:
+                continue
+
+            current_date = dateparser.parse(upload_time)
+            if not latest_date or current_date > latest_date:
                 latest_date = current_date
-            else:
-                if current_date > latest_date:
-                    latest_date = current_date
         return latest_date
 
 

--- a/packagedb/tests/test_package_managers.py
+++ b/packagedb/tests/test_package_managers.py
@@ -105,6 +105,24 @@ class TestPackageManagers(TestCase):
         results = list(PypiVersionAPI().fetch("django"))
         assert results == []
 
+    def test_pypi_get_latest_date_skips_missing_upload_time(self):
+        downloads = [
+            {},
+            {"upload_time_iso_8601": "2010-12-23T05:14:23.509436Z"},
+            {"upload_time_iso_8601": "2010-12-23T05:20:23.509436Z"},
+        ]
+
+        latest_date = PypiVersionAPI().get_latest_date(downloads)
+
+        assert latest_date == dt_local(2010, 12, 23, 5, 20, 23, 509436)
+
+    def test_pypi_get_latest_date_with_no_valid_upload_time(self):
+        downloads = [{}, {"url": "https://files.pythonhosted.org/example.whl"}]
+
+        latest_date = PypiVersionAPI().get_latest_date(downloads)
+
+        assert latest_date is None
+
     @mock.patch("packagedb.package_managers.get_response")
     def test_ruby_fetch_with_no_release(self, mock_response):
         with open(os.path.join(TEST_DATA, "gem.json")) as f:


### PR DESCRIPTION
Closes: #863 
## Summary

Fix `PypiVersionAPI.get_latest_date()` so PyPI release entries without
`upload_time_iso_8601` are skipped instead of causing an `UnboundLocalError`.

## Changes

- skip invalid download entries that do not include `upload_time_iso_8601`
- keep returning the latest valid parsed timestamp
- return `None` when no valid timestamps are available
- add regression tests for mixed valid/invalid entries
- add regression tests for the all-invalid case

## Why

The previous implementation could reference `current_date` before assignment
when a PyPI download entry was missing `upload_time_iso_8601`.

## Testing

I added coverage in `packagedb/tests/test_package_managers.py` for:

- entries with missing timestamps followed by valid ones
- entries with no valid timestamps
