### PR TITLE
Add on-demand indexing for Nixpkgs in PurlDB

### DIFF
--- a/minecode/collectors/nix.py
+++ b/minecode/collectors/nix.py
@@ -1,0 +1,187 @@
+#
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# purldb is a trademark of nexB Inc.
+# SPDX-License-Identifier: Apache-2.0
+# See http://www.apache.org/licenses/LICENSE-2.0 for the license text.
+# See https://github.com/nexB/purldb for support or download.
+# See https://aboutcode.org for more information about nexB OSS projects.
+#
+
+import logging
+import shutil
+import subprocess
+import json
+from packageurl import PackageURL
+from minecode.miners.nix import build_packages, verify_url_existence
+from fetchcode import fetch_json_response
+
+from minecode import priority_router
+from packagedb.models import PackageContentType
+
+logger = logging.getLogger(__name__)
+handler = logging.StreamHandler()
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
+
+def map_nix_package(package_url, pipelines, priority=0):
+    """
+    Add a composer `package_url` to the PackageDB.
+    """
+    from minecode.model_utils import add_package_to_scan_queue, merge_or_create_package
+
+    # Check if the `nix` command is available on the system
+    have_nix = False
+    if shutil.which("nix") is not None:
+        have_nix = True
+
+    namespace = package_url.namespace
+    # We will only work with the official nixpkgs repository.
+    # It is impossible to handle all third‑party or custom repositories.
+    if not namespace.lower() == "nixpkgs":
+        return None
+
+    data = get_nix_package_data(package_url)
+
+    if not data and have_nix:
+        data = get_nix_package_data_via_cli(package_url)
+        clean_garbage()
+
+    if data:
+        packages = build_packages(data, package_url)
+
+        error = None
+        for package in packages:
+            package.extra_data["package_content"] = PackageContentType.BINARY
+            db_package, _, _, error = merge_or_create_package(package, visit_level=0)
+            if error:
+                break
+
+            if db_package:
+                add_package_to_scan_queue(
+                    package=db_package, pipelines=pipelines, priority=priority
+                )
+
+        return error
+    else:
+        return f"Failed to fetch package data for {package_url}"
+
+
+def get_nix_package_data(purl):
+    """
+    Fetch package data from https://search.devbox.sh/.
+    """
+
+    api_url = f"https://search.devbox.sh/v2/pkg?name={purl.name}"
+    if not verify_url_existence(api_url):
+        return None
+
+    return fetch_json_response(api_url)
+
+
+def parse_license(license):
+    """
+    Parse a license object and return a string representation of the license.
+    """
+    if isinstance(license, dict):
+        return (
+            license.get("spdxId")
+            or license.get("fullName")
+            or license.get("shortName")
+            or str(license)
+        )
+    elif isinstance(license, list):
+        return [parse_license(item) for item in license]
+    else:
+        return str(license)
+
+
+def get_nix_package_data_via_cli(package_url):
+    """
+    Fetch package metadata using the Nix CLI (mainly for packages that
+    Devbox doesn't index).
+    """
+    # Create a Nix expression to pull just the fields we want.
+    package_name = package_url.name
+    package_version = package_url.version
+
+    nix_exp = f"""
+        let
+            pkgs = import <nixpkgs> {{}};
+            pkg = pkgs.{package_name};
+            outputNames = if pkg ? outputs then pkg.outputs else ["out"];
+        in {{
+            name = pkg.pname or pkg.name or "";
+            version = pkg.version or "";
+            storePath = pkg.outPath or "";
+            outputs = builtins.listToAttrs (map (name: {{ name = name; value = pkg.${{name}}.outPath; }}) outputNames);
+            description = pkg.meta.description or "";
+            homepage = pkg.meta.homepage or "";
+            license = pkg.meta.license or {{}};
+            system = pkg.system or "";
+        }}
+    """
+
+    cmd = ["nix-instantiate", "--eval", "--json", "--strict", "-E", nix_exp]
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)  # noqa: S603
+        pkg_data = json.loads(result.stdout)
+
+        version = pkg_data.get("version", "")
+        if package_version:
+            if not version or version != package_version:
+                print(f"Cannot find version: {package_version}, got {version}")
+                return None
+
+        output_list = [
+            {"name": pname, "path": ppath} for pname, ppath in pkg_data.get("outputs", {}).items()
+        ]
+
+        # Return a similar JSON layout as Devbox
+        return {
+            "summary": pkg_data.get("description", ""),
+            "homepage_url": pkg_data.get("homepage", ""),
+            "license": parse_license(pkg_data.get("license", {})),
+            "releases": [
+                {
+                    "version": version,
+                    "platforms": [{"system": pkg_data.get("system", ""), "outputs": output_list}],
+                }
+            ],
+        }
+    except Exception as e:
+        print(
+            f"Failed to fetch Nix package data for {package_url}: {e.stderr if hasattr(e, 'stderr') else e}"
+        )
+        return None
+
+
+def clean_garbage():
+    """
+    Delete all unreferenced downloaded tarballs and evaluation caches
+    """
+    nix_store = shutil.which("nix-store")
+    if nix_store:
+        subprocess.run([nix_store, "--gc"], capture_output=True)  # noqa: S603
+    else:
+        raise FileNotFoundError("nix-store not found in PATH")
+
+
+@priority_router.route("pkg:nix/nixpkgs/.*")
+def process_request(purl_str, **kwargs):
+    """
+    Process `priority_resource_uri` containing a nix Package URL (PURL).
+    """
+    from minecode.model_utils import DEFAULT_PIPELINES
+
+    addon_pipelines = kwargs.get("addon_pipelines", [])
+    pipelines = DEFAULT_PIPELINES + tuple(addon_pipelines)
+    priority = kwargs.get("priority", 0)
+
+    package_url = PackageURL.from_string(purl_str)
+
+    error_msg = map_nix_package(package_url, pipelines, priority)
+
+    if error_msg:
+        return error_msg

--- a/minecode/collectors/nix.py
+++ b/minecode/collectors/nix.py
@@ -79,21 +79,16 @@ def get_nix_package_data(purl):
     return fetch_json_response(api_url)
 
 
-def parse_license(license):
+def parse_license(license_data):
     """
     Parse a license object and return a string representation of the license.
     """
-    if isinstance(license, dict):
-        return (
-            license.get("spdxId")
-            or license.get("fullName")
-            or license.get("shortName")
-            or str(license)
-        )
-    elif isinstance(license, list):
-        return [parse_license(item) for item in license]
-    else:
-        return str(license)
+    return (
+        license_data.get("spdxId")
+        or license_data.get("fullName")
+        or license_data.get("shortName")
+        or str(license_data)
+    )
 
 
 def get_nix_package_data_via_cli(package_url):

--- a/minecode/miners/nix.py
+++ b/minecode/miners/nix.py
@@ -1,0 +1,127 @@
+#
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# purldb is a trademark of nexB Inc.
+# SPDX-License-Identifier: Apache-2.0
+# See http://www.apache.org/licenses/LICENSE-2.0 for the license text.
+# See https://github.com/nexB/purldb for support or download.
+# See https://aboutcode.org for more information about nexB OSS projects.
+#
+
+from packagedcode import models as scan_models
+from packageurl import PackageURL
+
+import requests
+
+
+def get_nix_download_url(path):
+    """
+    Construct a download url from cache.nixos.org based on the /nix/store/
+    path
+    """
+    narinfo_hash = path.replace("/nix/store/", "").split("-")[0]
+    narinfo_url = f"https://cache.nixos.org/{narinfo_hash}.narinfo"
+    url_path = get_narinfo_url(narinfo_url)
+    return f"https://cache.nixos.org/{url_path}"
+
+
+def get_narinfo_url(narinfo_url):
+    """
+    Visit the narinfo url, parsed and return the URL value
+    """
+    # Fetch the narinfo file
+    response = requests.get(narinfo_url)
+    response.raise_for_status()
+
+    # Parse line by line
+    for line in response.text.splitlines():
+        if line.startswith("URL:"):
+            # Strip off "URL:" and any whitespace
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+def build_packages(metadata_dict, purl):
+    package_version = purl.version
+
+    description = metadata_dict.get("summary", "")
+    homepage_url = metadata_dict.get("homepage_url", "")
+    license = metadata_dict.get("license", [])
+    extracted_license_statement = license if isinstance(license, list) else [license]
+
+    releases = metadata_dict.get("releases", [])
+    for release in releases:
+        version = release.get("version", "")
+        if package_version and version != package_version:
+            continue
+        common_data = dict(
+            name=purl.name,
+            namespace=purl.namespace,
+            version=version,
+            description=description,
+            homepage_url=homepage_url,
+            extracted_license_statement=extracted_license_statement,
+        )
+
+        platforms = release.get("platforms", "")
+        for platform in platforms:
+            date = platform.get("date") or None
+            platform_system = platform.get("system", "")
+            commit = platform.get("commit_hash", "")
+            platform_outputs = platform.get("outputs") or None
+
+            if not platform_outputs:
+                continue
+            for platform_output in platform_outputs:
+                output_name = platform_output.get("name")
+                path = platform_output.get("path")
+                narinfo_url = path.replace("/nix/store/", "").split("-")[0]
+                download_url = get_nix_download_url(narinfo_url)
+                download_data = dict(
+                    datasource_id="nix_pkginfo",
+                    type="nix",
+                    download_url=download_url,
+                    release_date=date,
+                )
+                download_data.update(common_data)
+                package = scan_models.PackageData.from_data(download_data)
+                package.datasource_id = "nix_api_metadata"
+                qualifiers = {}
+                if platform_system:
+                    qualifiers["system"] = platform_system
+                if commit:
+                    qualifiers["commit"] = commit
+                if output_name:
+                    qualifiers["output"] = output_name
+                updated_purl = update_purl_with_version_qualifiers(purl, version, qualifiers)
+                package.set_purl(updated_purl)
+                yield package
+
+
+def update_purl_with_version_qualifiers(purl, version, qualifiers):
+    """
+    Update a PackageURL with the given version and qualifiers.
+    """
+    return PackageURL(
+        type=purl.type,
+        namespace=purl.namespace,
+        name=purl.name,
+        version=version,
+        qualifiers=qualifiers,
+        subpath=purl.subpath,
+    )
+
+
+def verify_url_existence(url):
+    """
+    Perform a fast HTTP HEAD request to check if a generated URL is valid.
+    """
+    try:
+        response = requests.head(url, allow_redirects=True, timeout=5)
+        if response.status_code == 200:
+            return True
+        elif response.status_code in (403, 429, 409):  # forbidden, rate limit, conflict
+            return True  # resource exists but not accessible
+        else:
+            return False
+    except Exception:
+        return False

--- a/minecode/tests/collectors/test_nix.py
+++ b/minecode/tests/collectors/test_nix.py
@@ -1,0 +1,144 @@
+#
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# purldb is a trademark of nexB Inc.
+# SPDX-License-Identifier: Apache-2.0
+# See http://www.apache.org/licenses/LICENSE-2.0 for the license text.
+# See https://github.com/nexB/purldb for support or download.
+# See https://aboutcode.org for more information about nexB OSS projects.
+#
+
+import json
+import os
+
+from django.test import TestCase as DjangoTestCase
+
+from packageurl import PackageURL
+
+import packagedb
+from minecode.collectors import nix
+from minecode.tests import FIXTURES_REGEN
+from minecode.utils_test import JsonBasedTesting
+
+
+class NixPriorityQueueTests(JsonBasedTesting, DjangoTestCase):
+    test_data_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "testfiles")
+
+    def setUp(self):
+        super().setUp()
+        self.expected_json_loc = self.get_test_loc("nix/SDL_mixer_package-expected.json")
+        with open(self.expected_json_loc) as f:
+            self.expected_json_contents = json.load(f)
+        """
+        self.scan_package = NpmPackageJsonHandler._parse(
+            json_data=self.expected_json_contents,
+        )
+        """
+
+    def test_get_nix_package_data(self, regen=FIXTURES_REGEN):
+        purl = PackageURL.from_string("pkg:nix/nixpkgs/SDL_mixer@1.2.12")
+        json_contents = nix.get_nix_package_data(purl)
+        if regen:
+            with open(self.expected_json_loc, "w") as f:
+                json.dump(json_contents, f, indent=3, separators=(",", ":"))
+        self.assertEqual(self.expected_json_contents, json_contents)
+
+    def test_parse_license(self):
+        license_data = {
+            "deprecated": "false",
+            "free": "true",
+            "fullName": 'BSD 3-clause "New" or "Revised" License',
+            "licenseType": "simple",
+            "redistributable": "true",
+            "shortName": "bsd3",
+            "spdxId": "BSD-3-Clause",
+            "url": "https://spdx.org/licenses/BSD-3-Clause.html",
+        }
+        result = nix.parse_license(license_data)
+        self.assertEqual("BSD-3-Clause", result)
+
+    def test_get_nix_package_data_via_cli(self):
+        import shutil
+
+        if shutil.which("nix") is not None:
+            metadata = {
+                "summary": "Scientific tools for Python",
+                "homepage_url": "https://numpy.org/",
+                "license": "BSD-3-Clause",
+                "releases": [
+                    {
+                        "version": "2.4.4",
+                        "platforms": [
+                            {
+                                "system": "x86_64-linux",
+                                "outputs": [
+                                    {
+                                        "name": "dist",
+                                        "path": "/nix/store/3wmy167jrryy19h6i6hnfbzy4j0ndkma-python3.13-numpy-2.4.4-dist",
+                                    },
+                                    {
+                                        "name": "out",
+                                        "path": "/nix/store/l59n6vzkswz23y6s4pr6cmv2p4dpd5f0-python3.13-numpy-2.4.4",
+                                    },
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+            result = nix.get_nix_package_data_via_cli(
+                PackageURL.from_string("pkg:nix/nixpkgs/python3Packages.numpy@2.4.4")
+            )
+            self.assertEqual(metadata, result)
+
+    def test_map_nix_package(self):
+        package_count = packagedb.models.Package.objects.all().count()
+        self.assertEqual(0, package_count)
+        package_url = PackageURL.from_string("pkg:nix/nixpkgs/SDL_mixer@1.2.12")
+        nix.map_nix_package(package_url, ("test_pipeline"))
+        package_count = packagedb.models.Package.objects.all().count()
+        # There are 4 different systems and each system has 2 outputs, so
+        # we expect 8 packages to be created in total.
+        self.assertEqual(8, package_count)
+        # package = packagedb.models.Package.objects.all().first()
+        packages = packagedb.models.Package.objects.all()
+
+        expected_purl_data = [
+            (
+                "pkg:nix/nixpkgs/SDL_mixer@1.2.12?commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=out&system=aarch64-linux",
+                "https://cache.nixos.org/nar/07q6kl7ndvxi550gk7wm8j7m3lhbfbl5pshgx0amx38p4pq4haml.nar.zst",
+            ),
+            (
+                "pkg:nix/nixpkgs/SDL_mixer@1.2.12?commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=dev&system=aarch64-linux",
+                "https://cache.nixos.org/nar/13vh3dfwp5bcy75csf6l69zyxa8y9w0azy8drx9nacdqq84jzhl1.nar.zst",
+            ),
+            (
+                "pkg:nix/nixpkgs/SDL_mixer@1.2.12?commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=out&system=aarch64-darwin",
+                "https://cache.nixos.org/nar/10iscj2cnh5yhdgc5rnb9rmzr5galwmzmar495c9k410k7afc2kw.nar.zst",
+            ),
+            (
+                "pkg:nix/nixpkgs/SDL_mixer@1.2.12?commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=dev&system=aarch64-darwin",
+                "https://cache.nixos.org/nar/11zwp2lzw481agxqgg7f8ikj4zbivl7a2r0nvwsr107c963f59pl.nar.zst",
+            ),
+            (
+                "pkg:nix/nixpkgs/SDL_mixer@1.2.12?commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=out&system=x86_64-darwin",
+                "https://cache.nixos.org/nar/1y793cshy2hvdch0g3svi8bg0jlnx96jxsyi7960c1272cq7ricf.nar.zst",
+            ),
+            (
+                "pkg:nix/nixpkgs/SDL_mixer@1.2.12?commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=dev&system=x86_64-darwin",
+                "https://cache.nixos.org/nar/115jv555r5lnkgb2hp9p8qz31h5s1a4sgjdkbaf0cp9ccb6lvl4y.nar.zst",
+            ),
+            (
+                "pkg:nix/nixpkgs/SDL_mixer@1.2.12?commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=out&system=x86_64-linux",
+                "https://cache.nixos.org/nar/0phnvv0k4bnfb4mnjhldh4rksqy2pxsg53n6nh8zd7ikixq4q2qi.nar.zst",
+            ),
+            (
+                "pkg:nix/nixpkgs/SDL_mixer@1.2.12?commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=dev&system=x86_64-linux",
+                "https://cache.nixos.org/nar/1m1jh8jg98i0czg5hdiaa9yjmz48f0ldx8vwr2hbmlz65pcmrlls.nar.zst",
+            ),
+        ]
+
+        self.assertEqual(len(packages), len(expected_purl_data))
+
+        for package, (expected_purl, expected_url) in zip(packages, expected_purl_data):
+            self.assertEqual(expected_purl, package.purl)
+            self.assertEqual(expected_url, package.download_url)

--- a/minecode/tests/testfiles/nix/SDL_mixer_package-expected.json
+++ b/minecode/tests/testfiles/nix/SDL_mixer_package-expected.json
@@ -1,0 +1,92 @@
+{
+  "name": "SDL_mixer",
+  "summary": "SDL multi-channel audio mixer library",
+  "homepage_url": "http://www.libsdl.org/projects/SDL_mixer/",
+  "license": "Zlib",
+  "releases": [
+    {
+      "version": "1.2.12",
+      "last_updated": "2026-06-27T07:37:20Z",
+      "platforms": [
+        {
+          "arch": "arm64",
+          "os": "Linux",
+          "system": "aarch64-linux",
+          "attribute_path": "SDL_mixer",
+          "commit_hash": "3d46470bb3030020f7e1361f33514854f5bfa86d",
+          "date": "2026-06-27T07:37:20Z",
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/bgg1d95f9px23i9db6aal7cjbkdw025n-SDL_mixer-1.2.12",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/756a2pb6ynq0dr54wxbc25lsbm685v80-SDL_mixer-1.2.12-dev"
+            }
+          ]
+        },
+        {
+          "arch": "arm64",
+          "os": "macOS",
+          "system": "aarch64-darwin",
+          "attribute_path": "SDL_mixer",
+          "commit_hash": "3d46470bb3030020f7e1361f33514854f5bfa86d",
+          "date": "2026-06-27T07:37:20Z",
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/08l3d3zr073c2qxjy36642nd06jvykc0-SDL_mixer-1.2.12",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/5pndmp41940jv4w6y0y9m6hpa3c7b61y-SDL_mixer-1.2.12-dev"
+            }
+          ]
+        },
+        {
+          "arch": "x86-64",
+          "os": "macOS",
+          "system": "x86_64-darwin",
+          "attribute_path": "SDL_mixer",
+          "commit_hash": "3d46470bb3030020f7e1361f33514854f5bfa86d",
+          "date": "2026-06-27T07:37:20Z",
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/wb44wp28lx6jjdxdj1x384v02jkff5nm-SDL_mixer-1.2.12",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/kfz0d0r4mk70h8lvpyhr1zcxyiyld28i-SDL_mixer-1.2.12-dev"
+            }
+          ]
+        },
+        {
+          "arch": "x86-64",
+          "os": "Linux",
+          "system": "x86_64-linux",
+          "attribute_path": "SDL_mixer",
+          "commit_hash": "3d46470bb3030020f7e1361f33514854f5bfa86d",
+          "date": "2026-06-27T07:37:20Z",
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/4vpgs9snpddn62nqy1lyd3cr5wfa89di-SDL_mixer-1.2.12",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/kgzknkqwjywvf243dsrkl08d85ff06f8-SDL_mixer-1.2.12-dev"
+            }
+          ]
+        }
+      ],
+      "platforms_summary": "Linux and macOS",
+      "outputs_summary": "out, dev"
+    }
+  ]
+}


### PR DESCRIPTION
- Fixes: https://github.com/aboutcode-org/purldb/issues/758

The code will get the package's metadata from https://search.devbox.sh/v2/ and will use the `nix-instantiate` command if package cannot be found at devbox and `nix` is available in the host system.

Following are sample output:

Package: addic7ed-cli
http://127.0.0.1:8001/api/collect/?purl=pkg:nix/nixpkgs/addic7ed-cli
Reference: https://search.devbox.sh/v2/pkg?name=addic7ed-cli
```
HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

[
    {
        "url": "http://127.0.0.1:8001/api/packages/42d5f000-0119-4425-9f05-b86c4fd899e4/",
        "uuid": "42d5f000-0119-4425-9f05-b86c4fd899e4",
        "filename": "01rnl5zyvnijq80z9m2w3ymqqq8rc60dzxvl4ijzg5p5172h2ffs.nar.zst",
        "package_sets": [
            {
                "uuid": "690b8ea9-72b2-4f23-a56a-028681e6a2e1",
                "packages": [
                    "http://127.0.0.1:8001/api/packages/42d5f000-0119-4425-9f05-b86c4fd899e4/",
                    "http://127.0.0.1:8001/api/packages/6972296a-c0f9-4ae9-9216-399bf2c054ee/",
                    "http://127.0.0.1:8001/api/packages/bd83be40-7927-4a96-8784-8c2f2ec1a590/"
                ]
            },
            {
                "uuid": "e00b9c8e-09fb-4e23-a1c4-ff10ee7753a5",
                "packages": [
                    "http://127.0.0.1:8001/api/packages/42d5f000-0119-4425-9f05-b86c4fd899e4/",
                    "http://127.0.0.1:8001/api/packages/c17790c5-8a9b-4e7f-a353-d34a4b4f9640/",
                    "http://127.0.0.1:8001/api/packages/bd83be40-7927-4a96-8784-8c2f2ec1a590/"
                ]
            },
            {
                "uuid": "767a80db-d1ce-41ae-a8c8-ce1c3fd576a0",
                "packages": [
                    "http://127.0.0.1:8001/api/packages/42d5f000-0119-4425-9f05-b86c4fd899e4/",
                    "http://127.0.0.1:8001/api/packages/3c90894d-eb4c-481a-b2c0-1d419936e83e/",
                    "http://127.0.0.1:8001/api/packages/bd83be40-7927-4a96-8784-8c2f2ec1a590/"
                ]
            },
            {
                "uuid": "ff70d700-90f2-4ae8-9f02-ac4729ada6d9",
                "packages": [
                    "http://127.0.0.1:8001/api/packages/42d5f000-0119-4425-9f05-b86c4fd899e4/",
                    "http://127.0.0.1:8001/api/packages/4365dbb4-d620-4193-b63e-810d5c2d7971/",
                    "http://127.0.0.1:8001/api/packages/bd83be40-7927-4a96-8784-8c2f2ec1a590/"
                ]
            }
        ],
        "package_content": "binary",
        "purl": "pkg:nix/nixpkgs/addic7ed-cli@1.4.6?commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=out&system=x86_64-linux",
        "type": "nix",
        "namespace": "nixpkgs",
        "name": "addic7ed-cli",
        "version": "1.4.6",
        "qualifiers": "commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=out&system=x86_64-linux",
        "subpath": "",
        "primary_language": null,
        "description": "Commandline access to addic7ed subtitles",
        "release_date": "2026-06-27T07:37:20Z",
        "parties": [],
        "keywords": [],
        "homepage_url": "https://github.com/BenoitZugmeyer/addic7ed-cli",
        "download_url": "https://cache.nixos.org/nar/01rnl5zyvnijq80z9m2w3ymqqq8rc60dzxvl4ijzg5p5172h2ffs.nar.zst",
        "bug_tracking_url": null,
        "code_view_url": null,
        "vcs_url": null,
        "repository_homepage_url": null,
        "repository_download_url": null,
        "api_data_url": null,
        "size": null,
        "md5": null,
        "sha1": null,
        "sha256": null,
        "sha512": null,
        "copyright": null,
        "holder": null,
        "declared_license_expression": "mit",
        "declared_license_expression_spdx": "MIT",
        "license_detections": [
            {
                "matches": [
                    {
                        "score": 100.0,
                        "matcher": "1-spdx-id",
                        "end_line": 1,
                        "rule_url": null,
                        "from_file": null,
                        "start_line": 1,
                        "matched_text": "MIT",
                        "match_coverage": 100.0,
                        "matched_length": 1,
                        "rule_relevance": 100,
                        "rule_identifier": "spdx-license-identifier-mit-5da48780aba670b0860c46d899ed42a0f243ff06",
                        "license_expression": "mit",
                        "license_expression_spdx": "MIT"
                    }
                ],
                "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf",
                "license_expression": "mit",
                "license_expression_spdx": "MIT"
            }
        ],
        "other_license_expression": null,
        "other_license_expression_spdx": null,
        "other_license_detections": [],
        "extracted_license_statement": "- MIT\n",
        "notice_text": null,
        "source_packages": [],
        "extra_data": {},
        "package_uid": "pkg:nix/nixpkgs/addic7ed-cli@1.4.6?commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=out&system=x86_64-linux&uuid=42d5f000-0119-4425-9f05-b86c4fd899e4",
        "datasource_id": null,
        "file_references": [],
        "dependencies": [],
        "resources": "http://127.0.0.1:8001/api/packages/42d5f000-0119-4425-9f05-b86c4fd899e4/resources/",
        "history": "http://127.0.0.1:8001/api/packages/42d5f000-0119-4425-9f05-b86c4fd899e4/history/"
    },
    {
        "url": "http://127.0.0.1:8001/api/packages/c17790c5-8a9b-4e7f-a353-d34a4b4f9640/",
        "uuid": "c17790c5-8a9b-4e7f-a353-d34a4b4f9640",
        "filename": "0givq13zdrsvc9270mbxk6vmnb8xj77ig26yv0sv1ga3bimdjjjx.nar.zst",
        "package_sets": [
            {
                "uuid": "e00b9c8e-09fb-4e23-a1c4-ff10ee7753a5",
                "packages": [
                    "http://127.0.0.1:8001/api/packages/42d5f000-0119-4425-9f05-b86c4fd899e4/",
                    "http://127.0.0.1:8001/api/packages/c17790c5-8a9b-4e7f-a353-d34a4b4f9640/",
                    "http://127.0.0.1:8001/api/packages/bd83be40-7927-4a96-8784-8c2f2ec1a590/"
                ]
            }
        ],
        "package_content": "binary",
        "purl": "pkg:nix/nixpkgs/addic7ed-cli@1.4.6?commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=out&system=x86_64-darwin",
        "type": "nix",
        "namespace": "nixpkgs",
        "name": "addic7ed-cli",
        "version": "1.4.6",
        "qualifiers": "commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=out&system=x86_64-darwin",
        "subpath": "",
        "primary_language": null,
        "description": "Commandline access to addic7ed subtitles",
        "release_date": "2026-06-27T07:37:20Z",
        "parties": [],
        "keywords": [],
        "homepage_url": "https://github.com/BenoitZugmeyer/addic7ed-cli",
        "download_url": "https://cache.nixos.org/nar/0givq13zdrsvc9270mbxk6vmnb8xj77ig26yv0sv1ga3bimdjjjx.nar.zst",
        "bug_tracking_url": null,
        "code_view_url": null,
        "vcs_url": null,
        "repository_homepage_url": null,
        "repository_download_url": null,
        "api_data_url": null,
        "size": null,
        "md5": null,
        "sha1": null,
        "sha256": null,
        "sha512": null,
        "copyright": null,
        "holder": null,
        "declared_license_expression": "mit",
        "declared_license_expression_spdx": "MIT",
        "license_detections": [
            {
                "matches": [
                    {
                        "score": 100.0,
                        "matcher": "1-spdx-id",
                        "end_line": 1,
                        "rule_url": null,
                        "from_file": null,
                        "start_line": 1,
                        "matched_text": "MIT",
                        "match_coverage": 100.0,
                        "matched_length": 1,
                        "rule_relevance": 100,
                        "rule_identifier": "spdx-license-identifier-mit-5da48780aba670b0860c46d899ed42a0f243ff06",
                        "license_expression": "mit",
                        "license_expression_spdx": "MIT"
                    }
                ],
                "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf",
                "license_expression": "mit",
                "license_expression_spdx": "MIT"
            }
        ],
        "other_license_expression": null,
        "other_license_expression_spdx": null,
        "other_license_detections": [],
        "extracted_license_statement": "- MIT\n",
        "notice_text": null,
        "source_packages": [],
        "extra_data": {},
        "package_uid": "pkg:nix/nixpkgs/addic7ed-cli@1.4.6?commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=out&system=x86_64-darwin&uuid=c17790c5-8a9b-4e7f-a353-d34a4b4f9640",
        "datasource_id": null,
        "file_references": [],
        "dependencies": [],
        "resources": "http://127.0.0.1:8001/api/packages/c17790c5-8a9b-4e7f-a353-d34a4b4f9640/resources/",
        "history": "http://127.0.0.1:8001/api/packages/c17790c5-8a9b-4e7f-a353-d34a4b4f9640/history/"
    },
    {
        "url": "http://127.0.0.1:8001/api/packages/3c90894d-eb4c-481a-b2c0-1d419936e83e/",
        "uuid": "3c90894d-eb4c-481a-b2c0-1d419936e83e",
        "filename": "17mcfi5p9jj1gh4bpmm194zca9b7zmy13gn2fpgxmwfazz3d5ihs.nar.zst",
        "package_sets": [
            {
                "uuid": "767a80db-d1ce-41ae-a8c8-ce1c3fd576a0",
                "packages": [
                    "http://127.0.0.1:8001/api/packages/42d5f000-0119-4425-9f05-b86c4fd899e4/",
                    "http://127.0.0.1:8001/api/packages/3c90894d-eb4c-481a-b2c0-1d419936e83e/",
                    "http://127.0.0.1:8001/api/packages/bd83be40-7927-4a96-8784-8c2f2ec1a590/"
                ]
            }
        ],
        "package_content": "binary",
        "purl": "pkg:nix/nixpkgs/addic7ed-cli@1.4.6?commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=out&system=aarch64-linux",
        "type": "nix",
        "namespace": "nixpkgs",
        "name": "addic7ed-cli",
        "version": "1.4.6",
        "qualifiers": "commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=out&system=aarch64-linux",
        "subpath": "",
        "primary_language": null,
        "description": "Commandline access to addic7ed subtitles",
        "release_date": "2026-06-27T07:37:20Z",
        "parties": [],
        "keywords": [],
        "homepage_url": "https://github.com/BenoitZugmeyer/addic7ed-cli",
        "download_url": "https://cache.nixos.org/nar/17mcfi5p9jj1gh4bpmm194zca9b7zmy13gn2fpgxmwfazz3d5ihs.nar.zst",
        "bug_tracking_url": null,
        "code_view_url": null,
        "vcs_url": null,
        "repository_homepage_url": null,
        "repository_download_url": null,
        "api_data_url": null,
        "size": null,
        "md5": null,
        "sha1": null,
        "sha256": null,
        "sha512": null,
        "copyright": null,
        "holder": null,
        "declared_license_expression": "mit",
        "declared_license_expression_spdx": "MIT",
        "license_detections": [
            {
                "matches": [
                    {
                        "score": 100.0,
                        "matcher": "1-spdx-id",
                        "end_line": 1,
                        "rule_url": null,
                        "from_file": null,
                        "start_line": 1,
                        "matched_text": "MIT",
                        "match_coverage": 100.0,
                        "matched_length": 1,
                        "rule_relevance": 100,
                        "rule_identifier": "spdx-license-identifier-mit-5da48780aba670b0860c46d899ed42a0f243ff06",
                        "license_expression": "mit",
                        "license_expression_spdx": "MIT"
                    }
                ],
                "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf",
                "license_expression": "mit",
                "license_expression_spdx": "MIT"
            }
        ],
        "other_license_expression": null,
        "other_license_expression_spdx": null,
        "other_license_detections": [],
        "extracted_license_statement": "- MIT\n",
        "notice_text": null,
        "source_packages": [],
        "extra_data": {},
        "package_uid": "pkg:nix/nixpkgs/addic7ed-cli@1.4.6?commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=out&system=aarch64-linux&uuid=3c90894d-eb4c-481a-b2c0-1d419936e83e",
        "datasource_id": null,
        "file_references": [],
        "dependencies": [],
        "resources": "http://127.0.0.1:8001/api/packages/3c90894d-eb4c-481a-b2c0-1d419936e83e/resources/",
        "history": "http://127.0.0.1:8001/api/packages/3c90894d-eb4c-481a-b2c0-1d419936e83e/history/"
    },
    {
        "url": "http://127.0.0.1:8001/api/packages/4365dbb4-d620-4193-b63e-810d5c2d7971/",
        "uuid": "4365dbb4-d620-4193-b63e-810d5c2d7971",
        "filename": "0svrk6205zjm4vbf0hb8jhacams8gsjc25i7fwgm97mc1y2aygi8.nar.zst",
        "package_sets": [
            {
                "uuid": "ff70d700-90f2-4ae8-9f02-ac4729ada6d9",
                "packages": [
                    "http://127.0.0.1:8001/api/packages/42d5f000-0119-4425-9f05-b86c4fd899e4/",
                    "http://127.0.0.1:8001/api/packages/4365dbb4-d620-4193-b63e-810d5c2d7971/",
                    "http://127.0.0.1:8001/api/packages/bd83be40-7927-4a96-8784-8c2f2ec1a590/"
                ]
            }
        ],
        "package_content": "binary",
        "purl": "pkg:nix/nixpkgs/addic7ed-cli@1.4.6?commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=out&system=aarch64-darwin",
        "type": "nix",
        "namespace": "nixpkgs",
        "name": "addic7ed-cli",
        "version": "1.4.6",
        "qualifiers": "commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=out&system=aarch64-darwin",
        "subpath": "",
        "primary_language": null,
        "description": "Commandline access to addic7ed subtitles",
        "release_date": "2026-06-27T07:37:20Z",
        "parties": [],
        "keywords": [],
        "homepage_url": "https://github.com/BenoitZugmeyer/addic7ed-cli",
        "download_url": "https://cache.nixos.org/nar/0svrk6205zjm4vbf0hb8jhacams8gsjc25i7fwgm97mc1y2aygi8.nar.zst",
        "bug_tracking_url": null,
        "code_view_url": null,
        "vcs_url": null,
        "repository_homepage_url": null,
        "repository_download_url": null,
        "api_data_url": null,
        "size": null,
        "md5": null,
        "sha1": null,
        "sha256": null,
        "sha512": null,
        "copyright": null,
        "holder": null,
        "declared_license_expression": "mit",
        "declared_license_expression_spdx": "MIT",
        "license_detections": [
            {
                "matches": [
                    {
                        "score": 100.0,
                        "matcher": "1-spdx-id",
                        "end_line": 1,
                        "rule_url": null,
                        "from_file": null,
                        "start_line": 1,
                        "matched_text": "MIT",
                        "match_coverage": 100.0,
                        "matched_length": 1,
                        "rule_relevance": 100,
                        "rule_identifier": "spdx-license-identifier-mit-5da48780aba670b0860c46d899ed42a0f243ff06",
                        "license_expression": "mit",
                        "license_expression_spdx": "MIT"
                    }
                ],
                "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf",
                "license_expression": "mit",
                "license_expression_spdx": "MIT"
            }
        ],
        "other_license_expression": null,
        "other_license_expression_spdx": null,
        "other_license_detections": [],
        "extracted_license_statement": "- MIT\n",
        "notice_text": null,
        "source_packages": [],
        "extra_data": {},
        "package_uid": "pkg:nix/nixpkgs/addic7ed-cli@1.4.6?commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=out&system=aarch64-darwin&uuid=4365dbb4-d620-4193-b63e-810d5c2d7971",
        "datasource_id": null,
        "file_references": [],
        "dependencies": [],
        "resources": "http://127.0.0.1:8001/api/packages/4365dbb4-d620-4193-b63e-810d5c2d7971/resources/",
        "history": "http://127.0.0.1:8001/api/packages/4365dbb4-d620-4193-b63e-810d5c2d7971/history/"
    },
    {
        "url": "http://127.0.0.1:8001/api/packages/6972296a-c0f9-4ae9-9216-399bf2c054ee/",
        "uuid": "6972296a-c0f9-4ae9-9216-399bf2c054ee",
        "filename": "1im9xhbncc52kk3yx2iyzsi99qh5l0vzp82hy9v3naydz9gzpmjl.nar.zst",
        "package_sets": [
            {
                "uuid": "690b8ea9-72b2-4f23-a56a-028681e6a2e1",
                "packages": [
                    "http://127.0.0.1:8001/api/packages/42d5f000-0119-4425-9f05-b86c4fd899e4/",
                    "http://127.0.0.1:8001/api/packages/6972296a-c0f9-4ae9-9216-399bf2c054ee/",
                    "http://127.0.0.1:8001/api/packages/bd83be40-7927-4a96-8784-8c2f2ec1a590/"
                ]
            }
        ],
        "package_content": "binary",
        "purl": "pkg:nix/nixpkgs/addic7ed-cli@1.4.6?commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=dist&system=aarch64-darwin",
        "type": "nix",
        "namespace": "nixpkgs",
        "name": "addic7ed-cli",
        "version": "1.4.6",
        "qualifiers": "commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=dist&system=aarch64-darwin",
        "subpath": "",
        "primary_language": null,
        "description": "Commandline access to addic7ed subtitles",
        "release_date": "2026-06-27T07:37:20Z",
        "parties": [],
        "keywords": [],
        "homepage_url": "https://github.com/BenoitZugmeyer/addic7ed-cli",
        "download_url": "https://cache.nixos.org/nar/1im9xhbncc52kk3yx2iyzsi99qh5l0vzp82hy9v3naydz9gzpmjl.nar.zst",
        "bug_tracking_url": null,
        "code_view_url": null,
        "vcs_url": null,
        "repository_homepage_url": null,
        "repository_download_url": null,
        "api_data_url": null,
        "size": null,
        "md5": null,
        "sha1": null,
        "sha256": null,
        "sha512": null,
        "copyright": null,
        "holder": null,
        "declared_license_expression": "mit",
        "declared_license_expression_spdx": "MIT",
        "license_detections": [
            {
                "matches": [
                    {
                        "score": 100.0,
                        "matcher": "1-spdx-id",
                        "end_line": 1,
                        "rule_url": null,
                        "from_file": null,
                        "start_line": 1,
                        "matched_text": "MIT",
                        "match_coverage": 100.0,
                        "matched_length": 1,
                        "rule_relevance": 100,
                        "rule_identifier": "spdx-license-identifier-mit-5da48780aba670b0860c46d899ed42a0f243ff06",
                        "license_expression": "mit",
                        "license_expression_spdx": "MIT"
                    }
                ],
                "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf",
                "license_expression": "mit",
                "license_expression_spdx": "MIT"
            }
        ],
        "other_license_expression": null,
        "other_license_expression_spdx": null,
        "other_license_detections": [],
        "extracted_license_statement": "- MIT\n",
        "notice_text": null,
        "source_packages": [],
        "extra_data": {
            "package_content": 5
        },
        "package_uid": "pkg:nix/nixpkgs/addic7ed-cli@1.4.6?commit=3d46470bb3030020f7e1361f33514854f5bfa86d&output=dist&system=aarch64-darwin&uuid=6972296a-c0f9-4ae9-9216-399bf2c054ee",
        "datasource_id": "nix_api_metadata",
        "file_references": [],
        "dependencies": [],
        "resources": "http://127.0.0.1:8001/api/packages/6972296a-c0f9-4ae9-9216-399bf2c054ee/resources/",
        "history": "http://127.0.0.1:8001/api/packages/6972296a-c0f9-4ae9-9216-399bf2c054ee/history/"
    }
]
```

Package: python3Packages.numpy
http://127.0.0.1:8001/api/collect/?purl=pkg:nix/nixpkgs/python3Packages.numpy
No reference found in devbox: https://search.devbox.sh/v2/pkg?name=python3Packages.numpy
```
HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

[
    {
        "url": "http://127.0.0.1:8001/api/packages/3a248d82-66c1-4e6e-861b-693da10122c5/",
        "uuid": "3a248d82-66c1-4e6e-861b-693da10122c5",
        "filename": "00p5prnnrcz6yb96q4p6zpqlfrbn3r4f75289nc06bzw0qj6i0wy.nar.zst",
        "package_sets": [
            {
                "uuid": "34ca4e76-c47e-43e6-bb2b-abce048854e3",
                "packages": [
                    "http://127.0.0.1:8001/api/packages/d2aff49e-5b80-47e9-805c-b094523f05cc/",
                    "http://127.0.0.1:8001/api/packages/3a248d82-66c1-4e6e-861b-693da10122c5/",
                    "http://127.0.0.1:8001/api/packages/8165fefa-8b9c-4fd5-9a0b-69ddb093d1c7/"
                ]
            }
        ],
        "package_content": "binary",
        "purl": "pkg:nix/nixpkgs/python3Packages.numpy@2.4.4?output=out&system=x86_64-linux",
        "type": "nix",
        "namespace": "nixpkgs",
        "name": "python3Packages.numpy",
        "version": "2.4.4",
        "qualifiers": "output=out&system=x86_64-linux",
        "subpath": "",
        "primary_language": null,
        "description": "Scientific tools for Python",
        "release_date": null,
        "parties": [],
        "keywords": [],
        "homepage_url": "https://numpy.org/",
        "download_url": "https://cache.nixos.org/nar/00p5prnnrcz6yb96q4p6zpqlfrbn3r4f75289nc06bzw0qj6i0wy.nar.zst",
        "bug_tracking_url": null,
        "code_view_url": null,
        "vcs_url": null,
        "repository_homepage_url": null,
        "repository_download_url": null,
        "api_data_url": null,
        "size": null,
        "md5": null,
        "sha1": null,
        "sha256": null,
        "sha512": null,
        "copyright": null,
        "holder": null,
        "declared_license_expression": "bsd-new",
        "declared_license_expression_spdx": "BSD-3-Clause",
        "license_detections": [
            {
                "matches": [
                    {
                        "score": 100.0,
                        "matcher": "1-hash",
                        "end_line": 1,
                        "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
                        "from_file": null,
                        "start_line": 1,
                        "matched_text": "BSD-3-Clause",
                        "match_coverage": 100.0,
                        "matched_length": 3,
                        "rule_relevance": 100,
                        "rule_identifier": "bsd-new_10.RULE",
                        "license_expression": "bsd-new",
                        "license_expression_spdx": "BSD-3-Clause"
                    }
                ],
                "identifier": "bsd_new-50fa5753-f24d-ec04-33a1-36bb8ac0492c",
                "license_expression": "bsd-new",
                "license_expression_spdx": "BSD-3-Clause"
            }
        ],
        "other_license_expression": null,
        "other_license_expression_spdx": null,
        "other_license_detections": [],
        "extracted_license_statement": "- BSD-3-Clause\n",
        "notice_text": null,
        "source_packages": [],
        "extra_data": {},
        "package_uid": "pkg:nix/nixpkgs/python3Packages.numpy@2.4.4?output=out&system=x86_64-linux&uuid=3a248d82-66c1-4e6e-861b-693da10122c5",
        "datasource_id": null,
        "file_references": [],
        "dependencies": [],
        "resources": "http://127.0.0.1:8001/api/packages/3a248d82-66c1-4e6e-861b-693da10122c5/resources/",
        "history": "http://127.0.0.1:8001/api/packages/3a248d82-66c1-4e6e-861b-693da10122c5/history/"
    },
    {
        "url": "http://127.0.0.1:8001/api/packages/d2aff49e-5b80-47e9-805c-b094523f05cc/",
        "uuid": "d2aff49e-5b80-47e9-805c-b094523f05cc",
        "filename": "07vdkbbxgz7lisqxzryjp4qrz02zwjvcl0891b5j1nadn5gm1nv0.nar.xz",
        "package_sets": [
            {
                "uuid": "34ca4e76-c47e-43e6-bb2b-abce048854e3",
                "packages": [
                    "http://127.0.0.1:8001/api/packages/d2aff49e-5b80-47e9-805c-b094523f05cc/",
                    "http://127.0.0.1:8001/api/packages/3a248d82-66c1-4e6e-861b-693da10122c5/",
                    "http://127.0.0.1:8001/api/packages/8165fefa-8b9c-4fd5-9a0b-69ddb093d1c7/"
                ]
            }
        ],
        "package_content": "binary",
        "purl": "pkg:nix/nixpkgs/python3Packages.numpy@2.4.4?output=dist&system=x86_64-linux",
        "type": "nix",
        "namespace": "nixpkgs",
        "name": "python3Packages.numpy",
        "version": "2.4.4",
        "qualifiers": "output=dist&system=x86_64-linux",
        "subpath": "",
        "primary_language": null,
        "description": "Scientific tools for Python",
        "release_date": null,
        "parties": [],
        "keywords": [],
        "homepage_url": "https://numpy.org/",
        "download_url": "https://cache.nixos.org/nar/07vdkbbxgz7lisqxzryjp4qrz02zwjvcl0891b5j1nadn5gm1nv0.nar.xz",
        "bug_tracking_url": null,
        "code_view_url": null,
        "vcs_url": null,
        "repository_homepage_url": null,
        "repository_download_url": null,
        "api_data_url": null,
        "size": null,
        "md5": null,
        "sha1": null,
        "sha256": null,
        "sha512": null,
        "copyright": null,
        "holder": null,
        "declared_license_expression": "bsd-new",
        "declared_license_expression_spdx": "BSD-3-Clause",
        "license_detections": [
            {
                "matches": [
                    {
                        "score": 100.0,
                        "matcher": "1-hash",
                        "end_line": 1,
                        "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/bsd-new_10.RULE",
                        "from_file": null,
                        "start_line": 1,
                        "matched_text": "BSD-3-Clause",
                        "match_coverage": 100.0,
                        "matched_length": 3,
                        "rule_relevance": 100,
                        "rule_identifier": "bsd-new_10.RULE",
                        "license_expression": "bsd-new",
                        "license_expression_spdx": "BSD-3-Clause"
                    }
                ],
                "identifier": "bsd_new-50fa5753-f24d-ec04-33a1-36bb8ac0492c",
                "license_expression": "bsd-new",
                "license_expression_spdx": "BSD-3-Clause"
            }
        ],
        "other_license_expression": null,
        "other_license_expression_spdx": null,
        "other_license_detections": [],
        "extracted_license_statement": "- BSD-3-Clause\n",
        "notice_text": null,
        "source_packages": [],
        "extra_data": {},
        "package_uid": "pkg:nix/nixpkgs/python3Packages.numpy@2.4.4?output=dist&system=x86_64-linux&uuid=d2aff49e-5b80-47e9-805c-b094523f05cc",
        "datasource_id": null,
        "file_references": [],
        "dependencies": [],
        "resources": "http://127.0.0.1:8001/api/packages/d2aff49e-5b80-47e9-805c-b094523f05cc/resources/",
        "history": "http://127.0.0.1:8001/api/packages/d2aff49e-5b80-47e9-805c-b094523f05cc/history/"
    }
]
```

Note that if no version is provided, the code will try to get all the available version.
The purl follows the proposed syntax at https://github.com/package-url/purl-spec/pull/877